### PR TITLE
fix: Add claim/token validation to OIDC backend

### DIFF
--- a/rpcauth/backends.py
+++ b/rpcauth/backends.py
@@ -1,6 +1,8 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
 # -*- coding: utf-8 -*-
 
+import datetime
+
 from django.core.exceptions import SuspiciousOperation
 from django.db import IntegrityError
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
@@ -16,6 +18,11 @@ class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
       name - plain_name of the Person identified by sub
       roles - list of 2-tuples corresponding to Person's active roles
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._subject_id = None  # subject ID we are working with
+        self.OIDC_OP_ISSUER_ID = self.get_settings("OIDC_OP_ISSUER_ID")
 
     def create_user(self, claims):
         """Create a User following a successful auth"""
@@ -33,7 +40,9 @@ class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
             )
         except IntegrityError:
             # exception message gets logged - user only sees a failed auth
-            raise SuspiciousOperation(f"User already exists for datatracker person pk={subject_id}")
+            raise SuspiciousOperation(
+                f"User already exists for datatracker person pk={subject_id}"
+            )
         return new_user
 
     def update_user(self, user, claims):
@@ -56,16 +65,67 @@ class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
             datatracker_person__subject_id=claims["sub"],  # claim guaranteed to exist
         )
 
+    def verify_token(self, token, **kwargs):
+        payload = super().verify_token(token, **kwargs)
+        # Validation mandated by sect 3.1.3.7 of the spec not performed by base backend class
+        issuer_id = payload.get("iss", None)
+        if issuer_id is None or issuer_id != self.OIDC_OP_ISSUER_ID:
+            raise SuspiciousOperation(
+                'issuer "{}" does not match configured issuer "{}"'.format(
+                    issuer_id, self.OIDC_OP_ISSUER_ID
+                )
+            )
+        # Check audience. Per spec, we must reject the token if it "does not list the Client as a
+        # valid audience, or if it contains additional audiences not trusted by the Client." We only
+        # expect one audience from the datatracker, so let's assume any other audiences are untrusted.
+        audience = payload.get("aud", [])
+        if isinstance(audience, str):
+            audience = [audience]
+        if len(set(audience)) != 1 or audience[0] != self.OIDC_RP_CLIENT_ID:
+            raise SuspiciousOperation(
+                'token has invalid audience "{}"'.format(audience)
+            )
+        # azp should be present if token contains multiple audiences, but we rejected such a token already.
+        # Just check that, if present, azp is us
+        if "azp" in payload and payload["azp"] != self.OIDC_RP_CLIENT_ID:
+            raise SuspiciousOperation(
+                'token azp ("{}") is not our client id ("{}")'.format(
+                    payload["azp"], self.OIDC_RP_CLIENT_ID
+                )
+            )
+
+        if "exp" not in payload:
+            raise SuspiciousOperation("token has no expiration time")
+        if not isinstance(payload["exp"], int):
+            raise SuspiciousOperation('token exp claim ("{}") is not an integer')
+        expiration_time = datetime.datetime.fromtimestamp(
+            payload["exp"], tz=datetime.timezone.utc
+        )
+        if expiration_time < datetime.datetime.now(tz=datetime.timezone.utc):
+            raise SuspiciousOperation(f"token expired at {expiration_time}")
+
+        # remember the subject ID so we can validate claims later
+        if "sub" in payload:
+            self._subject_id = payload["sub"]
+        else:
+            raise SuspiciousOperation("No subject ID in token")
+        return payload
+
     def verify_claims(self, claims):
         """Verify that claims are sufficient to allow auth"""
         required_claims = {"sub", "roles"}
         if required_claims.intersection(claims.keys()) != required_claims:
             return False
 
-        # Per https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse, must validate sub in userinfo
-        # response
-        if claims["sub"] != self.OIDC_RP_CLIENT_ID:
-            raise SuspiciousOperation("userinfo sub does not match client ID")
+        # Per https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse,
+        # client must validate sub in userinfo response. The base class does not do that
+        # for us.
+        if claims["sub"] != self._subject_id:
+            raise SuspiciousOperation(
+                'userinfo sub ("{}") does not match token sub("{}")'.format(
+                    claims["sub"], self._subject_id
+                )
+            )
 
         # Check datatracker roles
         claim_roles = claims["roles"]

--- a/rpcauth/backends.py
+++ b/rpcauth/backends.py
@@ -60,6 +60,12 @@ class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
         required_claims = {"sub", "roles"}
         if required_claims.intersection(claims.keys()) != required_claims:
             return False
+
+        # Per https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse, must validate sub in userinfo
+        # response
+        if claims["sub"] != self.OIDC_RP_CLIENT_ID:
+            raise SuspiciousOperation("userinfo sub does not match client ID")
+
         # Check datatracker roles
         claim_roles = claims["roles"]
         return ["secr", "secretariat"] in claim_roles or ["auth", "rpc"] in claim_roles

--- a/rpcauth/backends.py
+++ b/rpcauth/backends.py
@@ -43,6 +43,7 @@ class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
         if plain_name is not None and plain_name != user.datatracker_person.plain_name:
             user.datatracker_person.plain_name = plain_name
             user.datatracker_person.save()
+        return user
 
     def filter_users_by_claims(self, claims):
         """Return list or queryset of users who satisfy claims

--- a/rpcauth/backends.py
+++ b/rpcauth/backends.py
@@ -132,7 +132,6 @@ class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
         if required_claims.intersection(claims.keys()) != required_claims:
             return False
 
-
         # Check datatracker roles
         claim_roles = claims["roles"]
         return ["secr", "secretariat"] in claim_roles or ["auth", "rpc"] in claim_roles

--- a/rpcauth/tests.py
+++ b/rpcauth/tests.py
@@ -51,7 +51,9 @@ class RpcOIDCAuthBackendTests(TestCase):
         self.assertIn("does not match configured issuer", str(cm.exception))
 
         # invalid audience
-        token_mock.return_value["iss"] = "http://issuer.example.com/openid"  # restore valid
+        token_mock.return_value[
+            "iss"
+        ] = "http://issuer.example.com/openid"  # restore valid
         token_mock.return_value["aud"] = "not-the-client"
         with self.assertRaises(SuspiciousOperation) as cm:
             self.backend.verify_token(fake_token)
@@ -130,7 +132,9 @@ class RpcOIDCAuthBackendTests(TestCase):
         self.assertIn("No subject ID claim", str(cm.exception))
 
         with self.assertRaises(SuspiciousOperation) as cm:
-            self.assertFalse(self.backend.verify_claims({"sub": "wrong-test-client-id", "roles": []}))
+            self.assertFalse(
+                self.backend.verify_claims({"sub": "wrong-test-client-id", "roles": []})
+            )
         self.assertIn("does not match token sub", str(cm.exception))
 
         # bad roles, good sub
@@ -150,6 +154,6 @@ class RpcOIDCAuthBackendTests(TestCase):
         )
         self.assertTrue(
             self.backend.verify_claims(
-                {"sub": "test-subject-id", "roles": [["secr", "secretariat"]]}
+                {"sub": "test-subject -id", "roles": [["secr", "secretariat"]]}
             )
         )

--- a/rpcauth/tests.py
+++ b/rpcauth/tests.py
@@ -1,3 +1,155 @@
-from django.test import TestCase
+# Copyright The IETF Trust 2023, All Rights Reserved
+# -*- coding: utf-8 -*-
 
-# Create your tests here.
+import datetime
+from unittest.mock import patch
+
+from django.core.exceptions import SuspiciousOperation
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from .backends import RpcOIDCAuthBackend
+
+
+class RpcOIDCAuthBackendTests(TestCase):
+    @override_settings(OIDC_OP_ISSUER_ID="http://issuer.example.com/openid")
+    @override_settings(OIDC_RP_CLIENT_ID="test-client-id")
+    @override_settings(OIDC_RP_CLIENT_SECRET="test-client-secret")
+    def setUp(self):
+        self.backend = RpcOIDCAuthBackend()
+
+    @patch("mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token")
+    def test_verify_token(self, token_mock):
+        # specify payload
+        token_mock.return_value = {
+            "iss": "http://issuer.example.com/openid",
+            "aud": "test-client-id",
+            "exp": int(
+                # now + 10 minutes
+                datetime.datetime.now(datetime.timezone.utc).timestamp()
+                + 600
+            ),
+            "sub": "test-subject-id",
+        }
+        fake_token = {}  # ignored by token_mock
+
+        self.assertEqual(
+            self.backend.verify_token(fake_token),
+            token_mock.return_value,
+        )
+
+        # invalid issuer
+        token_mock.return_value["iss"] = "http://other-issuer.example.com/openid"
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("does not match configured issuer", str(cm.exception))
+
+        # missing issuer
+        del token_mock.return_value["iss"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("does not match configured issuer", str(cm.exception))
+
+        # invalid audience
+        token_mock.return_value["iss"] = "http://issuer.example.com/openid"  # restore valid
+        token_mock.return_value["aud"] = "not-the-client"
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("has invalid audience", str(cm.exception))
+
+        token_mock.return_value["aud"] = ["test-client-id", "not-the-client"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("has invalid audience", str(cm.exception))
+
+        del token_mock.return_value["aud"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("has invalid audience", str(cm.exception))
+
+        # azp valid and present
+        token_mock.return_value["aud"] = "test-client-id"  # restore valid
+        token_mock.return_value["azp"] = "test-client-id"  # valid
+        self.assertEqual(
+            self.backend.verify_token(fake_token),
+            token_mock.return_value,
+        )
+
+        # azp invalid
+        token_mock.return_value["azp"] = "not-the-client"
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("is not our client id", str(cm.exception))
+
+        # expired token
+        del token_mock.return_value["azp"]
+        original_exp = token_mock.return_value["exp"]
+        token_mock.return_value["exp"] -= 610  # expired at least 10 seconds ago
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("token expired", str(cm.exception))
+
+        # no expiration
+        del token_mock.return_value["exp"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("has no expiration time", str(cm.exception))
+
+        # expiration not an integer
+        token_mock.return_value["exp"] = "about half past ten"
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("is not an integer", str(cm.exception))
+
+        # no sub
+        token_mock.return_value["exp"] = original_exp
+        del token_mock.return_value["sub"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.verify_token(fake_token)
+        self.assertIn("No subject ID", str(cm.exception))
+
+    @patch("mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token")
+    def test_verify_claims(self, token_mock):
+        # first call verify_token so the backend knows the "sub" claim to expect
+        token_mock.return_value = {
+            "iss": "http://issuer.example.com/openid",
+            "aud": "test-client-id",
+            "exp": int(
+                # now + 10 minutes
+                datetime.datetime.now(datetime.timezone.utc).timestamp()
+                + 600
+            ),
+            "sub": "test-subject-id",
+        }
+        fake_token = {}
+        self.backend.verify_token(fake_token)
+
+        # missing claims
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.assertFalse(self.backend.verify_claims({"roles": []}))
+        self.assertIn("No subject ID claim", str(cm.exception))
+
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.assertFalse(self.backend.verify_claims({"sub": "wrong-test-client-id", "roles": []}))
+        self.assertIn("does not match token sub", str(cm.exception))
+
+        # bad roles, good sub
+        self.assertFalse(
+            self.backend.verify_claims({"sub": "test-subject-id", "roles": []})
+        )
+        self.assertFalse(
+            self.backend.verify_claims(
+                {"sub": "test-subject-id", "roles": [["auth", "ietf-llc"]]}
+            )
+        )
+        # good roles and sub
+        self.assertTrue(
+            self.backend.verify_claims(
+                {"sub": "test-subject-id", "roles": [["auth", "rpc"]]}
+            )
+        )
+        self.assertTrue(
+            self.backend.verify_claims(
+                {"sub": "test-subject-id", "roles": [["secr", "secretariat"]]}
+            )
+        )

--- a/rpctracker/settings.py
+++ b/rpctracker/settings.py
@@ -104,6 +104,7 @@ OIDC_RP_CLIENT_SECRET = os.environ["OIDC_RP_CLIENT_SECRET"]
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = "openid profile roles"
 
+OIDC_OP_ISSUER_ID = "http://localhost:8000/api/openid"
 OIDC_OP_JWKS_ENDPOINT = "http://host.docker.internal:8000/api/openid/jwks/"
 OIDC_OP_AUTHORIZATION_ENDPOINT = (
     "http://localhost:8000/api/openid/authorize/"  # URL for user agent


### PR DESCRIPTION
This makes up for some shortcomings of mozilla-django-oidc's validation