### PR TITLE
fix: adjust rpc_person api to match model changes

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -18,7 +18,7 @@ def rpc_person(request):
         response.append(
             dict(
                 id=rpc_pers.pk,
-                name=rpc_pers.person.ascii_name(),
+                name=rpc_pers.datatracker_person.plain_name, # First use of stashed plain_name. Should we instead S2S query a batch of pks to get fresh names here?
                 capabilities=capabilities,
                 roles=roles,
             )


### PR DESCRIPTION
See the imbedded question.

@NGPixel asked if the client would ever touch the datatracker directly - this might be a place to ask.

If it _was_ setup to touch the datatracker directly, would we need to stash things like plain_name in the rpc database?