### PR TITLE
refactor: Rationalize the API usage a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ __pycache__
 
 /rpcapi.yaml
 /openapi/rpcapi_client
-/openapitools.json

--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -1,20 +1,11 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
 # -*- coding: utf-8 -*-
 
-import os
+import rpcapi_client
+from rpcapi_client.rest import ApiException
+from datatracker.rpcapi import ApiClient
 
-import rpcapi
-from rpcapi.rest import ApiException
-
-from django.conf import settings
 from django.db import models
-
-
-def get_api_client():
-    """Get an RPC API client"""
-    config = rpcapi.Configuration(host=settings.DATATRACKER_RPC_API_BASE)
-    config.api_key["ApiKeyAuth"] = settings.DATATRACKER_RPC_API_TOKEN
-    return rpcapi.ApiClient(config)
 
 
 class DatatrackerPerson(models.Model):
@@ -29,8 +20,8 @@ class DatatrackerPerson(models.Model):
         return f"Datatracker Person {self.datatracker_id}"
 
     def plain_name(self):
-        with get_api_client() as api_client:
-            api_instance = rpcapi.DefaultApi(api_client)
+        with ApiClient() as api_client:
+            api_instance = rpcapi_client.DefaultApi(api_client)
             try:
                 person = api_instance.get_person_by_id(int(self.datatracker_id))
             except ApiException as e:

--- a/datatracker/rpcapi.py
+++ b/datatracker/rpcapi.py
@@ -1,0 +1,17 @@
+# Copyright The IETF Trust 2023, All Rights Reserved
+
+import rpcapi_client
+
+from django.conf import settings
+
+
+class ApiClient(rpcapi_client.ApiClient):
+    """ApiClient that obtains credentials and sets API base automatically"""
+
+    def __init__(self):
+        super().__init__(
+            rpcapi_client.Configuration(
+                host=settings.DATATRACKER_RPC_API_BASE,
+                api_key={"ApiKeyAuth": settings.DATATRACKER_RPC_API_TOKEN}
+            )
+        )

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -10,7 +10,7 @@ git config oh-my-zsh.hide-info 1
 
 # Install requirements.txt dependencies
 wget -O rpcapi.yaml https://raw.githubusercontent.com/ietf-tools/datatracker/feat/rpc-api/rpcapi.yaml
-npx --yes @openapitools/openapi-generator-cli generate -i rpcapi.yaml -g python -o openapi/rpcapi_client -c openapi/config.yaml
+npx --yes @openapitools/openapi-generator-cli generate  # config in openapitools.json
 pip3 --disable-pip-version-check --no-cache-dir install --user --no-warn-script-location -r requirements.txt
 
 # Run nginx

--- a/openapi/config.yaml
+++ b/openapi/config.yaml
@@ -1,2 +1,4 @@
 additionalProperties:
-  packageName: rpcapi
+  packageName: rpcapi_client
+  # Set to false for OAS/JSON schema spec compliant behavior
+  disallowAdditionalPropertiesIfNotPresent: false

--- a/openapi/config.yaml
+++ b/openapi/config.yaml
@@ -1,4 +1,0 @@
-additionalProperties:
-  packageName: rpcapi_client
-  # Set to false for OAS/JSON schema spec compliant behavior
-  disallowAdditionalPropertiesIfNotPresent: false

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 4,
+  "generator-cli": {
+    "version": "7.0.1",
+    "generators": {
+      "default": {
+        "generatorName": "python",
+        "inputSpec": "#{cwd}/rpcapi.yaml",
+        "output": "#{cwd}/openapi/rpcapi_client",
+        "additionalProperties": {
+          "packageName": "rpcapi_client",
+          "disallowAdditionalPropertiesIfNotPresent": false
+        }
+      }
+    }
+  }
+}

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -2,8 +2,8 @@
 
 from django.http import JsonResponse
 
-import rpcapi
-from datatracker.models import get_api_client  # todo put this somewhere real
+import rpcapi_client
+from datatracker.rpcapi import ApiClient
 
 from .models import RpcPerson
 
@@ -65,8 +65,8 @@ def submissions(request):
     This api will filter those out.
     """
     submitted = []
-    with get_api_client() as api_client:
-        api = rpcapi.DefaultApi(api_client)
+    with ApiClient() as api_client:
+        api = rpcapi_client.DefaultApi(api_client)
         response = api.submitted_to_rpc()
         submitted.extend(response.to_dict()["submitted_to_rpc"])
     return JsonResponse({"submitted": submitted}, safe=False)

--- a/rpc/management/commands/create_rpc_demo.py
+++ b/rpc/management/commands/create_rpc_demo.py
@@ -3,8 +3,8 @@
 
 from django.core.management.base import BaseCommand
 
-import rpcapi
-from datatracker.models import get_api_client  # todo put this method somewhere sensible
+import rpcapi_client
+from datatracker.rpcapi import ApiClient
 
 from ...factories import RpcPersonFactory
 
@@ -18,11 +18,11 @@ class Command(BaseCommand):
 
     def create_rpc_people(self):
         # From "Manage Team Members" wireframe
-        with get_api_client() as api_client:
-            api = rpcapi.DefaultApi(api_client)
+        with ApiClient() as api_client:
+            api = rpcapi_client.client.DefaultApi(api_client)
             bjenkins = RpcPersonFactory(
                 datatracker_person__datatracker_id=api.create_demo_person(
-                    rpcapi.CreateDemoPersonRequest(name="B. Jenkins"),
+                    rpcapi_client.client.CreateDemoPersonRequest(name="B. Jenkins"),
                 ).person_pk,
                 can_hold_role=[
                     "formatting",
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="A. Travis"),
+                rpcapi_client.CreateDemoPersonRequest(name="A. Travis"),
             ).person_pk,
             can_hold_role=["formatting", "first_editor", "final_review_editor"],
             capable_of=["codecomp-abnf", "clusters-beginner", "ianaconsid-beginner"],
@@ -51,7 +51,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="Chuck Brown"),
+                rpcapi_client.CreateDemoPersonRequest(name="Chuck Brown"),
             ).person_pk,
             can_hold_role=["formatting"],
             capable_of=["clusters-beginner"],
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="C. Simmons"),
+                rpcapi_client.CreateDemoPersonRequest(name="C. Simmons"),
             ).person_pk,
             can_hold_role=[
                 "formatting",
@@ -78,7 +78,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="F. Fermat"),
+                rpcapi_client.CreateDemoPersonRequest(name="F. Fermat"),
             ).person_pk,
             can_hold_role=[
                 "formatting",
@@ -97,7 +97,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="K. Strawberry"),
+                rpcapi_client.CreateDemoPersonRequest(name="K. Strawberry"),
             ).person_pk,
             can_hold_role=["formatting", "first_editor"],
             capable_of=["ianaconsid-beginner", "xmlfmt-beginner"],
@@ -105,7 +105,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="O. Bleu"),
+                rpcapi_client.CreateDemoPersonRequest(name="O. Bleu"),
             ).person_pk,
             can_hold_role=[
                 "formatting",
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="Patricia Parker"),
+                rpcapi_client.CreateDemoPersonRequest(name="Patricia Parker"),
             ).person_pk,
             can_hold_role=[
                 "formatting",
@@ -145,7 +145,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="S. Bexar"),
+                rpcapi_client.CreateDemoPersonRequest(name="S. Bexar"),
             ).person_pk,
             can_hold_role=[
                 "formatting",
@@ -166,7 +166,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="T. Langfeld"),
+                rpcapi_client.CreateDemoPersonRequest(name="T. Langfeld"),
             ).person_pk,
             can_hold_role=["formatting", "first_editor"],
             capable_of=["ianaconsid-beginner", "xmlfmt-beginner"],
@@ -174,7 +174,7 @@ class Command(BaseCommand):
         )
         RpcPersonFactory(
             datatracker_person__datatracker_id=api.create_demo_person(
-                rpcapi.CreateDemoPersonRequest(name="U. Garrison"),
+                rpcapi_client.CreateDemoPersonRequest(name="U. Garrison"),
             ).person_pk,
             can_hold_role=["formatting"],
             capable_of=["xmlfmt-expert"],

--- a/update-rpcapi
+++ b/update-rpcapi
@@ -1,7 +1,8 @@
 #!/bin/sh -e
 # Run this in the container after updating rpcapi.yaml
 #
-npx --yes @openapitools/openapi-generator-cli generate -i rpcapi.yaml -g python -o openapi/rpcapi_client -c openapi/config.yaml
+# Configure the generator in openapitools.json
+npx --yes @openapitools/openapi-generator-cli generate
 pip3 --disable-pip-version-check --no-cache-dir install --user --no-warn-script-location -r requirements.txt
 
 echo


### PR DESCRIPTION
Mostly just gets a few things out of the `datatracker.models` file where they'd been stashed for convenience.

@NGPixel- could you check in particular the 3rd commit, which puts all the config for the code generator call into one file (the previously ignored `openapitools.json` file). It seems to work for me both with vscode and the old-fashioned way but I'm not familiar enough with vscode to be sure I didn't break it.