### PR TITLE
feat: Require auth to access backend api

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -82,6 +82,7 @@ def submissions(request, *, rpcapi: rpcapi_client.DefaultApi):
     return JsonResponse({"submitted": submitted}, safe=False)
 
 
+@api_view(["GET"])
 def queue(request):
     """Return documents currently in the queue
 
@@ -164,6 +165,7 @@ def queue(request):
     return JsonResponse(queue, safe=False)
 
 
+@api_view(["GET"])
 def clusters(request):
     """Return cluster index"""
     return JsonResponse(
@@ -184,6 +186,8 @@ def clusters(request):
     )
 
 
+
+@api_view(["GET"])
 def cluster(request, number):
     """Return data for a specific cluster"""
     try:

--- a/rpctracker/settings.py
+++ b/rpctracker/settings.py
@@ -123,12 +123,18 @@ SESSION_COOKIE_NAME = (
 )
 
 REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",
     ],
     "DEFAULT_PARSER_CLASSES": [
         "rest_framework.parsers.JSONParser",
-    ]
+    ],
 }
 
 # Password validation


### PR DESCRIPTION
Uses session-based authentication and requires authentication before permission is granted to access API endpoints.

Will apply to any views decorated with `@api_view` or any class-based `APIView` views (if we go that route later).