### PR TITLE
refactor: Use DRF viewset for label API

### DIFF
--- a/client/components/LabelEditDialog.vue
+++ b/client/components/LabelEditDialog.vue
@@ -100,13 +100,13 @@ console.log(label)
 console.log("Create "+props.create)
 
 async function save () {
-  await $fetch('/api/rpc/label/', {
+  await $fetch(props.create ? '/api/rpc/labels/' : `/api/rpc/labels/${props.label.slug}/`, {
     body: {
       slug: label.slug,
       is_exception: label.is_exception,
       color: label.color
     },
-    method: props.create? 'POST' : 'PUT',
+    method: props.create ? 'POST' : 'PUT',
     headers: { 'X-CSRFToken': csrf.value },
     onResponseError ({ response, error }) {
       snackbar.add({

--- a/client/pages/docs/[id].vue
+++ b/client/pages/docs/[id].vue
@@ -164,7 +164,7 @@ const csrf = useCookie('csrftoken', { sameSite: 'strict' })
 
 const appliedLabels = computed(() => labels.value.filter((lbl) => draft.value?.labels.includes(lbl.slug)))
 
-const { data: labels } = await useFetch('/api/rpc/label/', {
+const { data: labels } = await useFetch('/api/rpc/labels/', {
   baseURL: '/',
   server: false,
   default: () => ([])

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -40,7 +40,7 @@
 <script setup>
 import { LabelEditDialog } from '#components'
 
-const { data: labels, pending, refresh } = await useFetch('/api/rpc/label/', {
+const { data: labels, pending, refresh } = await useFetch('/api/rpc/labels/', {
   baseURL: '/',
   server: false,
   onRequestError ({ error }) {

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -1,9 +1,10 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
 
 from django.http import JsonResponse
-from django.shortcuts import get_object_or_404
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin, UpdateModelMixin, ListModelMixin
+from rest_framework.viewsets import GenericViewSet
 
 import rpcapi_client
 from datatracker.rpcapi import with_rpcapi
@@ -270,20 +271,12 @@ def rfc_to_be_labels(request, draftname=None, rfcnum=None):
             return Response(serializer.errors, status=400)
 
 
-@api_view(["GET", "POST", "PUT"])
-def label(request):
-    if request.method == "GET":
-        return Response(LabelSerializer(Label.objects.all(), many=True).data)
-    elif request.method == "POST":
-        serializer = LabelSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=201)
-        return Response(serializer.errors, status=400)
-    elif request.method == "PUT":
-        label = get_object_or_404(Label, slug=request.data["slug"])
-        serializer = LabelSerializer(label, data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=200)
-        return Response(serializer.errors, status=400)
+class LabelViewSet(
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+    GenericViewSet,
+):
+    queryset = Label.objects.all()
+    serializer_class = LabelSerializer

--- a/rpctracker/urls.py
+++ b/rpctracker/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path, register_converter
+from rest_framework import routers
 
 from rpc import views
 from rpc import api as rpc_api
@@ -44,6 +45,9 @@ class RfcNumberConverter:
 register_converter(DraftNameConverter, "draft-name")
 register_converter(RfcNumberConverter, "rfc-number")
 
+router = routers.DefaultRouter()
+router.register(r'labels', rpc_api.LabelViewSet)
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("oidc/", include("mozilla_django_oidc.urls")),
@@ -61,5 +65,6 @@ urlpatterns = [
     path("api/rpc/rpc_person/", rpc_api.rpc_person),
     path("api/rpc/submissions/", rpc_api.submissions),
     path("api/rpc/queue/", rpc_api.queue),
-    path("api/rpc/label/", rpc_api.label),
+    # path("api/rpc/label/", rpc_api.label),
+    path('api/rpc/', include(router.urls)),
 ]


### PR DESCRIPTION
This replaces the label management API with a DRF ViewSet implementation and adds the necessary URL routing plumbing.