### PR TITLE
feat: My Documents + other bits

### DIFF
--- a/client/components/HeaderNav.vue
+++ b/client/components/HeaderNav.vue
@@ -57,6 +57,32 @@
           <Icon name="solar:bell-bold-duotone" size="1.25em" aria-hidden="true" />
         </button>
 
+        <!-- Select User (for demo only) -->
+        <HeadlessMenu v-if="allUsers.length > 0" as="div" class="relative">
+          <HeadlessMenuButton class="-m-2.5 mx-2 text-gray-400 dark:text-neutral-400 hover:text-gray-500 dark:hover:text-violet-400">
+            <span class="sr-only">Select user (for demo only)</span>
+            <Icon name="solar:users-group-two-rounded-line-duotone" size="1.25em" aria-hidden="true" />
+          </HeadlessMenuButton>
+          <transition enter-active-class="transition ease-out duration-100" enter-from-class="transform opacity-0 scale-95" enter-to-class="transform opacity-100 scale-100" leave-active-class="transition ease-in duration-75" leave-from-class="transform opacity-100 scale-100" leave-to-class="transform opacity-0 scale-95">
+            <HeadlessMenuItems class="absolute left-0 z-10 mt-2.5 min-w-max origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
+              <HeadlessMenuItem v-if="userStore.pretendingToBe" v-slot="{ active }">
+                <div :class="[active ? 'bg-gray-50' : '', 'block px-3 py-1 text-sm leading-6 text-gray-900']"
+                     @click="switchUser(null)">
+                  Yourself
+                </div>
+              </HeadlessMenuItem>
+              <HeadlessMenuItem v-for="item in allUsers" :key="item.id" v-slot="{ active }">
+                <div :class="[active ? 'bg-gray-50' : '', 'block px-3 py-1 text-sm leading-6 text-gray-900']"
+                     @click="switchUser(item.id)">
+                  <Icon v-if="item.id === userStore.pretendingToBe"
+                        name="uil:arrow-right" class="h-6 w-6 -ml-1" aria-hidden="true" />
+                  {{ item.name }}
+                </div>
+              </HeadlessMenuItem>
+            </HeadlessMenuItems>
+          </transition>
+        </HeadlessMenu>
+
         <!-- Separator -->
         <div class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10 dark:lg:bg-white/20" aria-hidden="true" />
 
@@ -99,6 +125,7 @@
 import { useSiteStore } from '@/stores/site'
 import { useUserStore } from '@/stores/user'
 
+const api = useApi()
 const csrf = useCookie('csrftoken', { sameSite: 'strict' })
 
 async function logout () {
@@ -111,9 +138,31 @@ async function logout () {
 const siteStore = useSiteStore()
 const userStore = useUserStore()
 
+// FUNCTIONS
+
+function switchUser (rpcPersonId) {
+  userStore.pretendToBe(rpcPersonId)
+}
 // DATA
 
 const userNavigation = [
   { name: 'Your profile', href: '/' },
 ]
+
+const { data: allUsers } = await useAsyncData(
+  'allUsers',
+  async () => {
+    try {
+      return await api.rpcPersonList()
+    } catch {
+      // nop
+    }
+  },
+  {
+    default: () => ([]),
+    server: false,
+    transform: (resp) => resp.toSorted((a, b) => a.name.localeCompare(b.name))
+  }
+)
+
 </script>

--- a/client/components/SidebarNav.vue
+++ b/client/components/SidebarNav.vue
@@ -118,7 +118,7 @@ const currentBaseLink = computed(() => route.path.indexOf('/', 1) > 0 ? `/${rout
 const navigation = [
   { name: 'Dashboard', href: '/', icon: h(Icon, { name: 'solar:widget-6-bold-duotone' }) },
   { name: 'Queue', href: '/queue', icon: h(Icon, { name: 'solar:layers-minimalistic-bold-duotone' }) },
-  { name: 'Documents', href: '/docs', icon: h(Icon, { name: 'solar:documents-minimalistic-line-duotone' }) },
+  { name: 'My Documents', href: '/docs', icon: h(Icon, { name: 'solar:documents-minimalistic-line-duotone' }) },
   { name: 'Team', href: '/team', icon: h(Icon, { name: 'solar:users-group-rounded-bold-duotone' }) },
   { name: 'Statistics', href: '/stats', icon: h(Icon, { name: 'solar:chart-line-duotone' }) },
   { name: 'Final Reviews', href: '/auth48', icon: h(Icon, { name: 'solar:diploma-verified-broken' }) }

--- a/client/pages/docs/index.vue
+++ b/client/pages/docs/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <TitleBlock title="Documents" summary="Beep boop">
+  <TitleBlock title="My Documents" summary="Beep boop">
     <template #right>
       <RefreshButton class="mr-3"/>
       <NuxtLink

--- a/client/pages/docs/index.vue
+++ b/client/pages/docs/index.vue
@@ -1,13 +1,19 @@
 <template>
   <TitleBlock title="Documents" summary="Beep boop">
     <template #right>
-
+      <RefreshButton class="mr-3"/>
+      <NuxtLink
+        v-if="userStore.isManager"
+        class="max-w-l items-center rounded-md bg-violet-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        to="/docs/assignments">
+        Manage Assignments
+      </NuxtLink>
     </template>
   </TitleBlock>
   <div class="mt-8 flow-root">
-    <a href="/docs/assignments"
-       class="max-w-l items-center rounded-md bg-violet-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-      Manage Assignments
-    </a>
   </div>
 </template>
+
+<script setup>
+const userStore = useUserStore()
+</script>

--- a/client/stores/user.js
+++ b/client/stores/user.js
@@ -6,12 +6,18 @@ export const useUserStore = defineStore('user', {
     authenticated: false,
     name: 'Guest',
     email: '',
-    avatar: ''
+    avatar: '',
+    isManager: false,
+    pretendingToBe: null // demo/debug only!
   }),
   getters: {},
   actions: {
     async refreshAuth () {
-      const profileData = await $fetch('/api/rpc/profile')
+      const profileData = await $fetch(
+        this.pretendingToBe
+          ? `/api/rpc/profile/${this.pretendingToBe}`
+          : '/api/rpc/profile/'
+      )
       this.authenticated = profileData.authenticated
       if (this.authenticated) {
         this.id = profileData.id
@@ -20,6 +26,10 @@ export const useUserStore = defineStore('user', {
         this.avatar = profileData.avatar
         this.isManager = profileData.isManager
       }
+    },
+    async pretendToBe (rpcPersonId) {
+      this.pretendingToBe = rpcPersonId
+      return await this.refreshAuth()
     }
   }
 })

--- a/client/stores/user.js
+++ b/client/stores/user.js
@@ -18,6 +18,7 @@ export const useUserStore = defineStore('user', {
         this.name = profileData.name
         this.email = profileData.email
         this.avatar = profileData.avatar
+        this.isManager = profileData.isManager
       }
     }
   }

--- a/client/stores/user.js
+++ b/client/stores/user.js
@@ -7,6 +7,7 @@ export const useUserStore = defineStore('user', {
     name: 'Guest',
     email: '',
     avatar: '',
+    rpcPersonId: null,
     isManager: false,
     pretendingToBe: null // demo/debug only!
   }),
@@ -24,6 +25,7 @@ export const useUserStore = defineStore('user', {
         this.name = profileData.name
         this.email = profileData.email
         this.avatar = profileData.avatar
+        this.rpcPersonId = profileData.rpcPersonId
         this.isManager = profileData.isManager
       }
     },

--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -8,8 +8,18 @@ from datatracker.rpcapi import with_rpcapi
 from django.db import models
 
 
+class DatatrackerPersonQuerySet(models.QuerySet):
+    @with_rpcapi
+    def by_subject_id(self, subject_id, *, rpcapi: rpcapi_client.DefaultApi):
+        dtpers = rpcapi.get_subject_person_by_id(subject_id=subject_id)
+        if dtpers is None:
+            return super().none()
+        return super().filter(datatracker_id=dtpers.id)
+
+
 class DatatrackerPerson(models.Model):
     """Person known to the datatracker"""
+    objects = DatatrackerPersonQuerySet.as_manager()
 
     # datatracker uses AutoField for this, which is only an IntegerField, but might as well go big
     datatracker_id = models.BigIntegerField(

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -20,24 +20,33 @@ from .serializers import (
     QueueItemSerializer,
     RfcToBeSerializer,
     RpcPersonSerializer,
-    RpcRoleSerializer
+    RpcRoleSerializer,
 )
 
 
 @api_view(["GET"])
 @permission_classes([AllowAny])
-@with_rpcapi
-def profile(request, *, rpcapi: rpcapi_client.DefaultApi):
+def profile(request):
     """Get profile of current user"""
     user = request.user
     if not user.is_authenticated:
         return JsonResponse({"authenticated": False})
-    return JsonResponse({
-        "authenticated": True,
-        "id": user.pk,
-        "name": user.name,
-        "avatar": user.avatar,
-    })
+    dt_person = user.datatracker_person()
+    # hasattr() test also handles None case
+    rpcperson = dt_person.rpcperson if hasattr(dt_person, "rpcperson") else None
+    return JsonResponse(
+        {
+            "authenticated": True,
+            "id": user.pk,
+            "name": user.name,
+            "avatar": user.avatar,
+            "isManager": (
+                False
+                if rpcperson is None
+                else rpcperson.can_hold_role.filter(slug="manager").exists()
+            ),
+        }
+    )
 
 
 @extend_schema(responses=RpcPersonSerializer)
@@ -57,7 +66,9 @@ def rpc_person(request, *, rpcapi: rpcapi_client.DefaultApi):
     )
 
 
-@extend_schema(operation_id="submissions_list", responses=OpenApiTypes.OBJECT)  # not very specific...
+@extend_schema(
+    operation_id="submissions_list", responses=OpenApiTypes.OBJECT
+)  # not very specific...
 @api_view(["GET"])
 @with_rpcapi
 def submissions(request, *, rpcapi: rpcapi_client.DefaultApi):
@@ -101,9 +112,7 @@ def submissions(request, *, rpcapi: rpcapi_client.DefaultApi):
     # Filter out I-Ds that already have an RfcToBe
     already_in_queue = RfcToBe.objects.filter(
         draft__datatracker_id__in=[s["pk"] for s in submitted]
-    ).values_list(
-        "draft__datatracker_id", flat=True
-    )
+    ).values_list("draft__datatracker_id", flat=True)
     submitted = [s for s in submitted if s["pk"] not in already_in_queue]
     return JsonResponse({"submitted": submitted}, safe=False)
 
@@ -140,7 +149,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.DefaultApi):
                 "title": draft_info.title,
                 "stream": draft_info.stream,
                 "pages": draft_info.pages,
-            }
+            },
         )
 
     # Create the RfcToBe
@@ -154,8 +163,12 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.DefaultApi):
             submitted_boilerplate="trust200902",
             intended_boilerplate="trust200902",
             submitted_format="xml-v3",
-            submitted_std_level=StdLevelNameFactory(slug="ps", name="Proposed Standard").pk,
-            intended_std_level=StdLevelNameFactory(slug="ps", name="Proposed Standard").pk,
+            submitted_std_level=StdLevelNameFactory(
+                slug="ps", name="Proposed Standard"
+            ).pk,
+            intended_std_level=StdLevelNameFactory(
+                slug="ps", name="Proposed Standard"
+            ).pk,
             submitted_stream=StreamNameFactory(slug="ietf", name="IETF").pk,
             intended_stream=StreamNameFactory(slug="ietf", name="IETF").pk,
             internal_goal=initial_data["external_deadline"],
@@ -197,7 +210,6 @@ def clusters(request):
         ],
         safe=False,
     )
-
 
 
 @api_view(["GET"])

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -40,6 +40,7 @@ def profile(request):
             "id": user.pk,
             "name": user.name,
             "avatar": user.avatar,
+            "rpcPersonId": rpcperson.id if rpcperson is not None else None,
             "isManager": (
                 False
                 if rpcperson is None
@@ -62,6 +63,7 @@ def profile_as_person(request, rpc_person_id):
             "id": None,
             "name": rpcperson.datatracker_person.plain_name(),
             "avatar": f"https://i.pravatar.cc/150?u={rpcperson.datatracker_person.datatracker_id}",
+            "rpcPersonId": rpcperson.id,
             "isManager": (
                 False
                 if rpcperson is None

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -49,7 +49,28 @@ def profile(request):
     )
 
 
-@extend_schema(responses=RpcPersonSerializer)
+# This is for debugging / demo purposes only!
+@extend_schema(operation_id="profile_retrieve_demo_only", responses=OpenApiTypes.OBJECT)
+@api_view(["GET"])
+def profile_as_person(request, rpc_person_id):
+    rpcperson = RpcPerson.objects.filter(pk=rpc_person_id).first()
+    if rpcperson is None:
+        return Response(status=404)
+    return JsonResponse(
+        {
+            "authenticated": request.user.is_authenticated,
+            "id": None,
+            "name": rpcperson.datatracker_person.plain_name(),
+            "avatar": f"https://i.pravatar.cc/150?u={rpcperson.datatracker_person.datatracker_id}",
+            "isManager": (
+                False
+                if rpcperson is None
+                else rpcperson.can_hold_role.filter(slug="manager").exists()
+            ),
+        }
+    )
+
+@extend_schema(responses=RpcPersonSerializer(many=True))
 @api_view(["GET"])
 @with_rpcapi
 def rpc_person(request, *, rpcapi: rpcapi_client.DefaultApi):

--- a/rpc/management/commands/create_rpc_demo.py
+++ b/rpc/management/commands/create_rpc_demo.py
@@ -27,6 +27,32 @@ class Command(BaseCommand):
         self.people: dict[str, RpcPerson] = {}
         self.create_rpc_people()
         self.create_documents()
+        self.create_real_people()
+
+
+    @with_rpcapi
+    def create_real_people(self, *, rpcapi: rpcapi_client.DefaultApi):
+        """Create RpcPerson / DatatrackerPerson records for real people"""
+        self.people["jennifer"] = RpcPersonFactory(
+            datatracker_person__datatracker_id=rpcapi.get_subject_person_by_id(subject_id="14733").id,
+            can_hold_role=["manager"],
+        )
+        self.people["robert"] = RpcPersonFactory(
+            datatracker_person__datatracker_id=rpcapi.get_subject_person_by_id(subject_id="420").id,
+            can_hold_role=["manager"],
+        )
+        self.people["jean"] = RpcPersonFactory(
+            datatracker_person__datatracker_id=rpcapi.get_subject_person_by_id(subject_id="2706").id,
+            can_hold_role=["manager"],
+        )
+        self.people["sandy"] = RpcPersonFactory(
+            datatracker_person__datatracker_id=rpcapi.get_subject_person_by_id(subject_id="5709").id,
+            can_hold_role=["manager"],
+        )
+        self.people["alice"] = RpcPersonFactory(
+            datatracker_person__datatracker_id=rpcapi.get_subject_person_by_id(subject_id="2173").id,
+            can_hold_role=["manager"],
+        )
 
     @with_rpcapi
     def create_rpc_people(self, *, rpcapi: rpcapi_client.DefaultApi):

--- a/rpcauth/models.py
+++ b/rpcauth/models.py
@@ -4,6 +4,8 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
+from datatracker.models import DatatrackerPerson
+
 
 class User(AbstractUser):
     """RPC tool user class"""
@@ -21,3 +23,6 @@ class User(AbstractUser):
     )
 
     avatar = models.URLField(blank=True)
+
+    def datatracker_person(self):
+        return DatatrackerPerson.objects.by_subject_id(self.datatracker_subject_id).first()

--- a/rpctracker/urls.py
+++ b/rpctracker/urls.py
@@ -57,7 +57,8 @@ urlpatterns = [
     path("login/", views.index),
     path("api/rpc/clusters/", rpc_api.clusters),
     path("api/rpc/clusters/<int:number>", rpc_api.cluster),
-    path("api/rpc/profile", rpc_api.profile),
+    path("api/rpc/profile/", rpc_api.profile),
+    path("api/rpc/profile/<int:rpc_person_id>", rpc_api.profile_as_person),  # for demo only
     path("api/rpc/rpc_person/", rpc_api.rpc_person),
     path("api/rpc/submissions/", rpc_api.submissions),
     path("api/rpc/submissions/<int:document_id>/", rpc_api.submission),


### PR DESCRIPTION
This is a bunch of pieces aimed at showing the current user's documents on the Documents tab, renamed to My Documents.

To do this, passes the RpcPerson ID for the current user to the front end as part of the profile. This is used to filter the full list of assignments down to those assigned to the current user. I suspect we'll eventually want to add API endpoints so we can do this without giving non-manager people access to the full assignment data, but that's for another day.

Additionally passes an `isManager` flag that is use to show (or not) the "Manage Assignments" button on the "My Document" page. This can also be used to show/hide other UI elements ("Manage Clusters", etc?), but I haven't done that yet.

To make this easier to demo, I've added the ability to "pretendToBe" a different user without logging out. This is accessed by a new button in the header nav bar which gives a list of known identities. Switching to one will populate the `userStore` from a TEMPORARY endpoint that yields the details for the requested user. As a result, the UI will show up as though you were logged in as that person. This lasts until you do a reload of the page or select "Yourself" from the list. It _does_ persist while navigating through the site.