### PR TITLE
feat: Hide mgmt items from non-managers

### DIFF
--- a/client/components/SidebarNav.vue
+++ b/client/components/SidebarNav.vue
@@ -73,8 +73,8 @@
               </li>
             </ul>
           </li>
-          <li>
-            <div class="text-xs font-semibold leading-6 text-gray-400 dark:text-violet-400">Misc</div>
+          <li v-if="userStore.isManager">
+            <div class="text-xs font-semibold leading-6 text-gray-400 dark:text-violet-400">Management</div>
             <ul role="list" class="-mx-2 mt-2 space-y-1">
               <li v-for="link in links" :key="link.name">
                 <NuxtLink :to="link.href" :class="[link.href === currentBaseLink ? 'bg-gray-50 text-violet-600' : 'text-gray-700 dark:text-violet-300 hover:text-violet-600 hover:bg-gray-50 dark:hover:bg-violet-800', 'group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold']">
@@ -107,6 +107,7 @@ import confetti from 'canvas-confetti'
 // STORES
 
 const siteStore = useSiteStore()
+const userStore = useUserStore()
 
 // ROUTER
 
@@ -124,12 +125,15 @@ const navigation = [
   { name: 'Final Reviews', href: '/auth48', icon: h(Icon, { name: 'solar:diploma-verified-broken' }) }
 ]
 
-const links = [
-  { name: 'Manage RFC Numbers', href: '/rfcs', icon: h(Icon, { name: 'fluent-mdl2:number-field' }) },
-  { name: 'Cluster Management', href: '/clusters', icon: h(Icon, { name: 'pajamas:group' }) },
-  { name: 'Legal Requests', href: '/legal', icon: h(Icon, { name: 'octicon:law-24' }) },
-  { name: 'Manage Labels', href: '/labels', icon: h(Icon, { name: 'pajamas:labels' }) }
-]
+const links = computed(() => userStore.isManager
+  ? [
+      { name: 'Manage RFC Numbers', href: '/rfcs', icon: h(Icon, { name: 'fluent-mdl2:number-field' }) },
+      { name: 'Cluster Management', href: '/clusters', icon: h(Icon, { name: 'pajamas:group' }) },
+      { name: 'Legal Requests', href: '/legal', icon: h(Icon, { name: 'octicon:law-24' }) },
+      { name: 'Manage Labels', href: '/labels', icon: h(Icon, { name: 'pajamas:labels' }) }
+  ]
+  : []
+)
 
 // METHODS
 

--- a/client/components/SidebarNav.vue
+++ b/client/components/SidebarNav.vue
@@ -73,8 +73,8 @@
               </li>
             </ul>
           </li>
-          <li v-if="userStore.isManager">
-            <div class="text-xs font-semibold leading-6 text-gray-400 dark:text-violet-400">Management</div>
+          <li>
+            <div class="text-xs font-semibold leading-6 text-gray-400 dark:text-violet-400">Misc</div>
             <ul role="list" class="-mx-2 mt-2 space-y-1">
               <li v-for="link in links" :key="link.name">
                 <NuxtLink :to="link.href" :class="[link.href === currentBaseLink ? 'bg-gray-50 text-violet-600' : 'text-gray-700 dark:text-violet-300 hover:text-violet-600 hover:bg-gray-50 dark:hover:bg-violet-800', 'group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold']">
@@ -125,15 +125,21 @@ const navigation = [
   { name: 'Final Reviews', href: '/auth48', icon: h(Icon, { name: 'solar:diploma-verified-broken' }) }
 ]
 
-const links = computed(() => userStore.isManager
-  ? [
-      { name: 'Manage RFC Numbers', href: '/rfcs', icon: h(Icon, { name: 'fluent-mdl2:number-field' }) },
-      { name: 'Cluster Management', href: '/clusters', icon: h(Icon, { name: 'pajamas:group' }) },
-      { name: 'Legal Requests', href: '/legal', icon: h(Icon, { name: 'octicon:law-24' }) },
-      { name: 'Manage Labels', href: '/labels', icon: h(Icon, { name: 'pajamas:labels' }) }
-  ]
-  : []
-)
+const links = computed(() => {
+  const val = userStore.isManager
+    ? [
+        { name: 'Manage RFC Numbers', href: '/rfcs', icon: h(Icon, { name: 'fluent-mdl2:number-field' }) },
+        { name: 'Cluster Management', href: '/clusters', icon: h(Icon, { name: 'pajamas:group' }) },
+        { name: 'Legal Requests', href: '/legal', icon: h(Icon, { name: 'octicon:law-24' }) }
+      ]
+    : []
+
+  // links for everyone
+  val.push(
+    { name: 'Manage Labels', href: '/labels', icon: h(Icon, { name: 'pajamas:labels' }) }
+  )
+  return val
+})
 
 // METHODS
 

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -8,6 +8,7 @@
           <a v-for="item in secondaryNavigation" :key="item.name" :href="item.href" :class="item.current ? 'text-violet-600 dark:text-violet-500' : 'text-gray-700 dark:text-neutral-500'">{{ item.name }}</a>
         </div>
         <button
+          v-if="userStore.isManager"
           @click="addDocument"
           class="ml-auto flex items-center gap-x-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
           >
@@ -36,6 +37,8 @@
 
 <script setup>
 import { TestOverlay } from '#components'
+
+const userStore = useUserStore()
 
 const snackbar = useSnackbar()
 

--- a/client/pages/team/index.vue
+++ b/client/pages/team/index.vue
@@ -3,7 +3,9 @@
               summary="A list of all the users having access to this tool.">
     <template #right>
       <RefreshButton :pending="pending" @refresh="refresh" class="mr-3"/>
-      <button type="button" @click="newTeamMember"
+      <button v-if="userStore.isManager"
+              type="button"
+              @click="newTeamMember"
               class="flex items-center rounded-md bg-violet-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
         <Icon name="uil:plus" class="-ml-1 h-5 w-5 mr-2" aria-hidden="true"/>
         New Team Member
@@ -47,6 +49,8 @@ const { openOverlayModal } = inject('overlayModal')
 useHead({
   title: 'Manage Team Members'
 })
+
+const userStore = useUserStore()
 
 // METHODS
 


### PR DESCRIPTION
Among the changes, hides the "Add team member" button. Not sure if we want to entirely hide the "Team" page or not. It's currently titled "Manage Team Members," but maybe editors should get a "View Team Members"?