### PR TITLE
feat: Basic RfcToBe history tracking

### DIFF
--- a/client/pages/docs/[id].vue
+++ b/client/pages/docs/[id].vue
@@ -106,7 +106,7 @@
       class="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
       <div
         class="-mx-4 px-4 py-8 bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5 sm:mx-0 sm:rounded-lg sm:px-8 sm:pb-14 lg:col-span-2 lg:row-span-2 lg:row-end-2 xl:px-16 xl:pb-20 xl:pt-16">
-        <h2 class="text-base font-semibold leading-6 text-gray-900">History (mocked)</h2>
+        <h2 class="text-base font-semibold leading-6 text-gray-900">History</h2>
         <div class="flex">
           <table class="min-w-full divide-y divide-gray-300">
             <thead class="bg-gray-50">
@@ -117,7 +117,7 @@
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
-              <tr v-for="entry in history" :key="history.id">
+              <tr v-for="entry of draft?.history ?? []" :key="entry.id">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">{{ entry.date }}</td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ entry.by }}</td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ entry.desc }}</td>
@@ -153,10 +153,4 @@ async function saveLabels (labels) {
     })
   }
 }
-
-const history = [
-  { id: 1, date: '2022-12-31', by: 'C. Brown', desc: 'Added to queue' },
-  { id: 2, date: '2022-12-31', by: 'C. Brown', desc: 'Added Label: Needs Formatting' },
-]
-
 </script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django>=4.2.5
+django-simple-history>=3.4
 djangorestframework>=3.14
 drf-spectacular>=0.26
 factory-boy>=3.3

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -71,15 +71,17 @@ class RfcToBeSerializer(serializers.ModelSerializer):
     def get_cluster(self, rfc_to_be) -> Optional[int]:
         return rfc_to_be.cluster.number if rfc_to_be.cluster else None
 
-    def get_history(self, rfc_to_be) -> list[tuple[datetime.datetime, str]]:
+    def get_history(self, rfc_to_be) -> list[dict]:
         history = []
         for newer, older in pairwise(rfc_to_be.history.all()):
             delta = newer.diff_against(older)
             if delta.changes:
-                history.append((
-                    newer.history_date,
-                    "; ".join(f"{ch.field} changed from {ch.old} to {ch.new}" for ch in delta.changes)
-                ))
+                history.append({
+                    "id": newer.history_id,
+                    "date": newer.history_date,
+                    "by": newer.history_user.name if newer.history_user else None,
+                    "desc": "; ".join(f"{ch.field} changed from {ch.old} to {ch.new}" for ch in delta.changes)
+                })
         return history
 
 

--- a/rpctracker/settings.py
+++ b/rpctracker/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "drf_spectacular",
     "rest_framework",
+    "simple_history",
     "datatracker.apps.DatatrackerConfig",
     "rpc.apps.RpcConfig",
     "rpcauth.apps.RpcAuthConfig",
@@ -56,6 +57,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "simple_history.middleware.HistoryRequestMiddleware",
 ]
 
 ROOT_URLCONF = "rpctracker.urls"


### PR DESCRIPTION
Adds django-simple-history and adds history tracking of the `RfcToBe` model, including the `labels` many-to-may relationship. This is serialized through the API and displayed on the document page in a very rudimentary way.

The approach here is a combination of tagging historical models with explicit change reasons (for annotating the "Added to the queue" event when an RfcToBe is created) and on-the-fly descriptions (for describing changes to the models).

Significant refactoring will (hopefully obviously) be needed, but getting this out as-is to provide something concrete for discussion.