### PR TITLE
fix: DocumentTable sort column width wobble.

### DIFF
--- a/client/components/DocumentTable.vue
+++ b/client/components/DocumentTable.vue
@@ -14,8 +14,15 @@
               <span>{{ col.label }}</span>
               <template v-if="state.sortField === col.field">
                 <Icon v-if="state.sortDirection === 'asc'" name="uil:arrow-up" class="text-lg -mt-0.5" />
-                <Icon v-else name="uil:arrow-down" class="text-lg -mt-0.5" />
+                <Icon v-else-if="state.sortDirection === 'desc'" name="uil:arrow-down" class="text-lg -mt-0.5" />
               </template>
+              <template v-else>
+                <!-- else render a placeholder icon see https://github.com/ietf-tools/rpc/issues/49 -->
+                <Icon
+                  name="uil:arrow-down"
+                  class="text-lg -mt-0.5 opacity-0"
+                />
+            </template>
             </a>
             <span v-else>{{ col.label }}</span>
           </th>


### PR DESCRIPTION
Adds a placeholder icon to each column so that each column has the same width regardless of whether it's sorted.

fixes #49

question: does this need tests? I'm guessing not.

We should probably consider changing the `<a>`s to be `<button>`s and use [`aria-sort`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) for a11y reasons.