### PR TITLE
fix: dark mode

### DIFF
--- a/client/components/HeaderNav.vue
+++ b/client/components/HeaderNav.vue
@@ -111,7 +111,7 @@
           </transition>
         </HeadlessMenu>
         <div v-else class="-m-1.5 flex items-center p-1.5">
-          <a href="/oidc/authenticate/" class="hidden lg:flex items-center text-sm">
+          <a href="/oidc/authenticate/" class="hidden lg:flex items-center text-sm dark:text-neutral-300">
             <span class="font-semibold">Login</span>
             <Icon name="solar:alt-arrow-right-line-duotone" size="1.5em" class="ml-1" />
           </a>

--- a/client/components/RpcLabelPicker.vue
+++ b/client/components/RpcLabelPicker.vue
@@ -1,6 +1,6 @@
 <template>
   <HeadlessCombobox as="div" v-model="selectedLabels" multiple>
-    <HeadlessComboboxLabel class="block text-sm font-medium leading-6 text-gray-900">
+    <HeadlessComboboxLabel class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-300">
       {{ props.label }}
     </HeadlessComboboxLabel>
     <div class="relative mt-2">

--- a/client/components/TitleBlock.vue
+++ b/client/components/TitleBlock.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="lg:flex lg:items-center lg:justify-between">
+  <div class="lg:flex lg:items-center lg:justify-between text-gray-500 dark:text-neutral-300">
     <div class="min-w-0 flex-1">
-      <h2 class="text-2xl font-bold leading-7 dark:text-neutral-300 sm:truncate sm:text-3xl sm:tracking-tight">{{ title }}</h2>
+      <h2 class="text-2xl font-bold leading-7 sm:truncate sm:text-3xl sm:tracking-tight">{{ title }}</h2>
       <div v-if="summary" class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
-        <div class="mt-2 flex items-center text-sm dark:text-neutral-300">
+        <div class="mt-2 flex items-center text-sm">
           {{ summary }}
         </div>
       </div>

--- a/client/components/TitleBlock.vue
+++ b/client/components/TitleBlock.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="lg:flex lg:items-center lg:justify-between">
     <div class="min-w-0 flex-1">
-      <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">{{ title }}</h2>
+      <h2 class="text-2xl font-bold leading-7 dark:text-neutral-300 sm:truncate sm:text-3xl sm:tracking-tight">{{ title }}</h2>
       <div v-if="summary" class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
-        <div class="mt-2 flex items-center text-sm text-gray-500">
+        <div class="mt-2 flex items-center text-sm dark:text-neutral-300">
           {{ summary }}
         </div>
       </div>

--- a/client/pages/docs/[id].vue
+++ b/client/pages/docs/[id].vue
@@ -10,10 +10,10 @@
 
     <div class="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
       <div class="mx-auto flex max-w-2xl items-center justify-between gap-x-8 lg:mx-0 lg:max-w-none">
-        <div class="flex items-center gap-x-6">
+        <div class="flex items-center gap-x-6 text-gray-900 dark:text-white">
           <Icon name="solar:document-text-line-duotone" class="w-10 h-10"/>
           <h1>
-            <div class="mt-1 text-xl font-semibold leading-6 text-gray-900 dark:text-white">
+            <div class="mt-1 text-xl font-semibold leading-6">
               <span v-if="draft">{{ draft.name }}-{{ draft.rev }}</span>
             </div>
           </h1>
@@ -29,10 +29,10 @@
       <!-- Status summary -->
       <div class="lg:col-start-3 lg:row-start-1 lg:row-span-1 grid place-items-stretch">
         <h2 class="sr-only">Status Summary</h2>
-        <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5">
+        <div class="rounded-lg bg-white text-gray-900 dark:bg-neutral-900 dark:text-neutral-300 shadow-sm ring-1 ring-gray-900/5">
           <div class="px-4 pt-6 sm:px-6">
-            <h3 class="text-base font-semibold leading-7 text-gray-900">Current Assignments</h3>
-            <div class="mx-4 text-sm font-medium text-gray-900">
+            <h3 class="text-base font-semibold leading-7">Current Assignments</h3>
+            <div class="mx-4 text-sm font-medium ">
               <div v-if="draftAssignments.length === 0">
                 None
               </div>
@@ -47,9 +47,9 @@
               </dl>
             </div>
           </div>
-          <div class="px-4 py-6 sm:px-6">
-            <h3 class="text-base font-semibold leading-7 text-gray-900">Queue Information (mocked)</h3>
-            <div class="mx-4 text-sm font-medium text-gray-900">
+          <div class="px-4 py-6 sm:px-6 text-gray-900 dark:text-neutral-300">
+            <h3 class="text-base font-semibold leading-7 ">Queue Information (mocked)</h3>
+            <div class="mx-4 text-sm font-medium">
               <dl>
                 <div class="py-1 grid grid-cols-2">
                   <dt>Current State</dt>
@@ -79,12 +79,12 @@
       </div>
 
       <!-- Document Info -->
-      <div class="lg:col-span-2 lg:row-span-2 lg:row-start-1 grid place-items-stretch">
+      <div class="lg:col-span-2 lg:row-span-2 lg:row-start-1 grid place-items-stretch text-gray-900 dark:bg-neutral-900 text-gray-900 dark:text-neutral-300">
         <h2 class="sr-only">Main panel</h2>
         <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5">
           <div class="px-4 py-6 sm:px-6">
-            <h3 class="text-base font-semibold leading-7 text-gray-900">Document Info</h3>
-            <div class="mx-4 pb-3 text-sm font-medium text-gray-900">
+            <h3 class="text-base font-semibold leading-7">Document Info</h3>
+            <div class="mx-4 pb-3 text-sm font-medium">
               <dl>
                 <div class="px-4 pt-3 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
                   <dt>Title</dt>
@@ -162,11 +162,11 @@
       </div>
 
       <!-- Labels -->
-      <div class="lg:col-start-3 lg:row-start-2 lg:row-span-1 grid place-items-stretch">
+      <div class="lg:col-start-3 lg:row-start-2 lg:row-span-1 grid place-items-stretch text-gray-900 dark:text-neutral-300">
         <h2 class="sr-only">Label panel</h2>
         <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5">
           <div class="px-4 py-6 sm:px-6">
-            <h3 class="text-base font-semibold leading-7 text-gray-900">Labels</h3>
+            <h3 class="text-base font-semibold leading-7">Labels</h3>
             <div class="flex">
               <div v-for="lbl of appliedLabels" class="flex-shrink-0 p-1">
                 <RpcLabel :label="lbl"/>
@@ -179,39 +179,39 @@
       </div>
 
       <!-- History -->
-      <div class="lg:col-span-full grid place-items-stretch">
+      <div class="lg:col-span-full grid place-items-stretch text-gray-900 dark:text-neutral-300">
         <h2 class="sr-only">History panel</h2>
         <div class="rounded-lg bg-white dark:bg-neutral-900 shadow-sm ring-1 ring-gray-900/5">
           <div class="px-4 py-6 sm:px-6">
-            <h3 class="text-base font-semibold leading-7 text-gray-900">History</h3>
+            <h3 class="text-base font-semibold leading-7">History</h3>
             <div class="flex">
               <table class="min-w-full divide-y divide-gray-300">
-                <thead class="bg-gray-50">
-                <tr>
-                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Date</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">By</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Description</th>
-                </tr>
+                <thead class="bg-gray-50 dark:bg-neutral-800">
+                  <tr>
+                    <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold sm:pl-6">Date</th>
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">By</th>
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Description</th>
+                  </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-200 bg-white">
-                <tr v-for="entry of draft?.history ?? []" :key="entry.id">
-                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                    <time :datetime="DateTime.fromObject(entry.date).toISO()">
-                      {{ DateTime.fromObject(entry.date).toLocaleString(DateTime.DATE_MED) }}
-                    </time>
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <NuxtLink v-if="entry.by?.personId"
-                              :to="`/team/${entry.by.personId}`"
-                              class="text-violet-900 hover:text-violet-500 dark:text-violet-300 hover:dark:text-violet-100">
-                      {{ entry.by.name }}
-                    </NuxtLink>
-                    <span v-else>
-                      {{ entry.by?.name }}
-                    </span>
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ entry.desc }}</td>
-                </tr>
+                <tbody class="divide-y divide-gray-200">
+                  <tr v-for="entry of draft?.history ?? []" :key="entry.id">
+                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium sm:pl-6">
+                      <time :datetime="DateTime.fromObject(entry.date).toISO()">
+                        {{ DateTime.fromObject(entry.date).toLocaleString(DateTime.DATE_MED) }}
+                      </time>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm">
+                      <NuxtLink v-if="entry.by?.personId"
+                                :to="`/team/${entry.by.personId}`"
+                                class="text-violet-900 hover:text-violet-500 dark:text-violet-300 hover:dark:text-violet-100">
+                        {{ entry.by.name }}
+                      </NuxtLink>
+                      <span v-else>
+                        {{ entry.by?.name }}
+                      </span>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm">{{ entry.desc }}</td>
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/client/pages/labels/index.vue
+++ b/client/pages/labels/index.vue
@@ -2,7 +2,7 @@
   <div class="px-4 sm:px-6 lg:px-8">
     <div class="sm:flex sm:items-center">
       <div class="sm:flex-auto">
-        <h1 class="text-base font-semibold leading-6 text-gray-900">Labels</h1>
+        <h1 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-300">Labels</h1>
       </div>
       <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
         <button @click="addLabel()" type="button" class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Add Label</button>

--- a/client/pages/stats.vue
+++ b/client/pages/stats.vue
@@ -1,5 +1,5 @@
 <template>
-  <table>
+  <table class="text-gray-900 dark:text-neutral-300">
     <thead>
     <tr>
       <th>Label</th>


### PR DESCRIPTION
Fixes #81 (in the sense that it fixes some current components/pages but I may have missed some)

Mostly this adds some Tailwind `dark:*` CSS classes, and—where possible—moves inline classes up to a container class to avoid repetition.