### PR TITLE
feat: Group assignments by person

### DIFF
--- a/client/components/DocumentTable.vue
+++ b/client/components/DocumentTable.vue
@@ -140,7 +140,11 @@ function sortBy (fieldName) {
  */
 function buildCell (col, row) {
   const values = isArray(row[col.field]) ? row[col.field] : [row[col.field]]
-  const formattedValues = col.format ? values.map(v => col.format(v)) : values
+  const formattedValues = col.format
+    ? col.formatType === 'all'
+      ? col.format(values)
+      : values.map(v => col.format(v))
+    : values
   const children = []
 
   const isLink = isFunction(col.link)


### PR DESCRIPTION
Currently names are repeated for each role, but this groups roles by person

![Screenshot from 2024-08-19 19-33-57](https://github.com/user-attachments/assets/9d6fa67e-8c8b-40b3-baf6-8926bffc8b88)
