### PR TITLE
fix: camelCase several API names

### DIFF
--- a/client/components/DocumentCard.vue
+++ b/client/components/DocumentCard.vue
@@ -172,7 +172,7 @@ const cookedDocument = computed(() => {
 
   return ({
     ...props.document,
-    external_deadline: props.document.external_deadline && DateTime.fromISO(props.document.external_deadline),
+    external_deadline: props.document.externalDeadline && DateTime.fromJSDate(props.document.externalDeadline),
     assignments: props.document.assignments,
     assignmentsPersons,
     assignmentsPersonIds: assignmentsPersons?.map(editor => editor?.id),
@@ -180,7 +180,8 @@ const cookedDocument = computed(() => {
       ?.map(editor => ({
         ...editor,
         assignedDocuments: props?.editorAssignedDocuments?.[editor.id],
-        completeBy: currentTime.value.plus({ days: 7 * props.document.pages / teamPagesPerHour / editor.hours_per_week })
+        // @ts-expect-error - drf-spectacular incorrectly marks hoursPerWeek as possibly undefined in the API schema
+        completeBy: currentTime.value.plus({ days: 7 * props.document.pages / teamPagesPerHour / editor.hoursPerWeek })
       }))
       .sort((a, b) => a.completeBy.toMillis() - b.completeBy.toMillis())
   })


### PR DESCRIPTION
Noticed a few places where we still had snake case names in JS code. The API generator converts these.