### PR TITLE
chore(deps): Node.js v22

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,7 +32,7 @@
         "@types/humanize-duration": "3.27.4",
         "@types/lodash-es": "4.17.12",
         "@types/luxon": "3.4.2",
-        "@types/node": "<21",
+        "@types/node": "~22",
         "@types/sortablejs": "1.15.8",
         "eslint": "9.9.1",
         "eslint-plugin-nuxt": "4.0.0",
@@ -2816,9 +2816,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.16.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
-      "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
+      "version": "22.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "@types/humanize-duration": "3.27.4",
     "@types/lodash-es": "4.17.12",
     "@types/luxon": "3.4.2",
-    "@types/node": "<21",
+    "@types/node": "~22",
     "@types/sortablejs": "1.15.8",
     "eslint": "9.9.1",
     "eslint-plugin-nuxt": "4.0.0",

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 # Add Node.js Source
 RUN mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Add PostgreSQL Source
 RUN echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \


### PR DESCRIPTION
Node.js v22 becomes the LTS version in October 2024