### PR TITLE
fix: remove field from labels col

### DIFF
--- a/client/components/DocumentTable.vue
+++ b/client/components/DocumentTable.vue
@@ -12,7 +12,7 @@
             :aria-sort="state.sortField === col.field ? state.sortDirection === 'asc' ? 'ascending' : 'descending' : undefined"
           >
             <button
-              v-if="col.sortable !== false"
+              v-if="col.sortable !== false && col.field"
               class="bg-transparent border-none"
               :aria-pressed="state.sortField === col.field"
               @click.prevent="sortBy(col.field)">
@@ -43,7 +43,7 @@
             :key="col.key"
             :class="[
               'px-3 py-4 text-gray-500 dark:text-neutral-400',
-              col.classes && isFunction(col.classes) ? col.classes(row[col.field]) : col.classes
+              col.classes && isFunction(col.classes) ? col.classes(col.field ? row[col.field] : row) : col.classes
             ]"
           >
             <component :is="buildCell(col, row)" />
@@ -123,7 +123,7 @@ function sortBy (fieldName: string) {
  * Build cell node
  */
 function buildCell (col: Column, row: Row) {
-  const value = row[col.field]
+  const value = col.field ? row[col.field] : null
   const values = isArray(value) ? value : [value]
   const formattedValues = col.format
     ? col.formatType === 'all'

--- a/client/components/DocumentTableTypes.ts
+++ b/client/components/DocumentTableTypes.ts
@@ -10,7 +10,7 @@ export interface Column {
   label: string
   labels?: (row: Row) => string[]
   labelDefaultColor?: ColorEnum
-  field: string
+  field?: string
   classes?: string | ((val: Value) => string)
   sortable?: boolean
   link?: string | ((row: Row, val: Value) => string)

--- a/client/pages/queue/[section].vue
+++ b/client/pages/queue/[section].vue
@@ -109,7 +109,6 @@ const columns = computed(() => {
     },
     {
       key: 'labels',
-      field: 'labels',
       label: 'Labels',
       labels: (row) => (row.labels || []) as string[]
     }


### PR DESCRIPTION
Fixes #209 

This creates a problem because the `labels` field is a `Label` object and `<DocumentTable>` can't deal with it.

It was added as part of the typescript conversion and I'm not certain why, but I don't think it's needed functionally.