### PR TITLE
ci: datatracker StatefulSet

### DIFF
--- a/k8s/datatracker-settings_local.py
+++ b/k8s/datatracker-settings_local.py
@@ -29,7 +29,7 @@ _SECRET_KEY = os.environ.get("DATATRACKER_DJANGO_SECRET_KEY", None)
 if _SECRET_KEY is not None:
     SECRET_KEY = _SECRET_KEY
 else:
-    raise RuntimeError("DATATRACKER_DJANGO_SECRET_KEY must be set")    
+    raise RuntimeError("DATATRACKER_DJANGO_SECRET_KEY must be set")
 
 _NOMCOM_APP_SECRET_B64 = os.environ.get("DATATRACKER_NOMCOM_APP_SECRET_B64", None)
 if _NOMCOM_APP_SECRET_B64 is not None:
@@ -41,7 +41,7 @@ _IANA_SYNC_PASSWORD = os.environ.get("DATATRACKER_IANA_SYNC_PASSWORD", None)
 if _IANA_SYNC_PASSWORD is not None:
     IANA_SYNC_PASSWORD = _IANA_SYNC_PASSWORD
 else:
-    raise RuntimeError("DATATRACKER_IANA_SYNC_PASSWORD must be set")    
+    raise RuntimeError("DATATRACKER_IANA_SYNC_PASSWORD must be set")
 
 _RFC_EDITOR_SYNC_PASSWORD = os.environ.get("DATATRACKER_RFC_EDITOR_SYNC_PASSWORD", None)
 if _RFC_EDITOR_SYNC_PASSWORD is not None:
@@ -59,25 +59,25 @@ _GITHUB_BACKUP_API_KEY = os.environ.get("DATATRACKER_GITHUB_BACKUP_API_KEY", Non
 if _GITHUB_BACKUP_API_KEY is not None:
     GITHUB_BACKUP_API_KEY = _GITHUB_BACKUP_API_KEY
 else:
-    raise RuntimeError("DATATRACKER_GITHUB_BACKUP_API_KEY must be set")    
+    raise RuntimeError("DATATRACKER_GITHUB_BACKUP_API_KEY must be set")
 
 _API_KEY_TYPE = os.environ.get("DATATRACKER_API_KEY_TYPE", None)
 if _API_KEY_TYPE is not None:
     API_KEY_TYPE = _API_KEY_TYPE
 else:
-    raise RuntimeError("DATATRACKER_API_KEY_TYPE must be set")    
+    raise RuntimeError("DATATRACKER_API_KEY_TYPE must be set")
 
 _API_PUBLIC_KEY_PEM_B64 = os.environ.get("DATATRACKER_API_PUBLIC_KEY_PEM_B64", None)
 if _API_PUBLIC_KEY_PEM_B64 is not None:
     API_PUBLIC_KEY_PEM = b64decode(_API_PUBLIC_KEY_PEM_B64)
 else:
-    raise RuntimeError("DATATRACKER_API_PUBLIC_KEY_PEM_B64 must be set")    
+    raise RuntimeError("DATATRACKER_API_PUBLIC_KEY_PEM_B64 must be set")
 
 _API_PRIVATE_KEY_PEM_B64 = os.environ.get("DATATRACKER_API_PRIVATE_KEY_PEM_B64", None)
 if _API_PRIVATE_KEY_PEM_B64 is not None:
     API_PRIVATE_KEY_PEM = b64decode(_API_PRIVATE_KEY_PEM_B64)
 else:
-    raise RuntimeError("DATATRACKER_API_PRIVATE_KEY_PEM_B64 must be set")    
+    raise RuntimeError("DATATRACKER_API_PRIVATE_KEY_PEM_B64 must be set")
 
 # Set DEBUG if DATATRACKER_DEBUG env var is the word "true"
 DEBUG = os.environ.get("DATATRACKER_DEBUG", "false").lower() == "true"
@@ -114,7 +114,7 @@ _admins_str = os.environ.get("DATATRACKER_ADMINS", None)
 if _admins_str is not None:
     ADMINS = [parseaddr(admin) for admin in _multiline_to_list(_admins_str)]
 else:
-    raise RuntimeError("DATATRACKER_ADMINS must be set")    
+    raise RuntimeError("DATATRACKER_ADMINS must be set")
 
 USING_DEBUG_EMAIL_SERVER = os.environ.get("DATATRACKER_EMAIL_DEBUG", "false").lower() == "true"
 EMAIL_HOST = os.environ.get("DATATRACKER_EMAIL_HOST", "localhost")
@@ -155,7 +155,7 @@ _MEETECHO_CLIENT_SECRET = os.environ.get("DATATRACKER_MEETECHO_CLIENT_SECRET", N
 if _MEETECHO_CLIENT_ID is not None and _MEETECHO_CLIENT_SECRET is not None:
     MEETECHO_API_CONFIG = {
         "api_base": os.environ.get(
-            "DATATRACKER_MEETECHO_API_BASE", 
+            "DATATRACKER_MEETECHO_API_BASE",
             "https://meetings.conf.meetecho.com/api/v1/",
         ),
         "client_id": _MEETECHO_CLIENT_ID,
@@ -231,43 +231,33 @@ DJANGO_VITE_MANIFEST_PATH = os.path.join(BASE_DIR, 'static/dist-neue/manifest.js
 DE_GFM_BINARY = "/usr/local/bin/de-gfm"
 IDSUBMIT_IDNITS_BINARY = "/usr/local/bin/idnits"
 
-# Duplicating production cache from settings.py and using it whether we're in production mode or not
-MEMCACHED_HOST = os.environ.get("DT_MEMCACHED_SERVICE_HOST", "127.0.0.1")
-MEMCACHED_PORT = os.environ.get("DT_MEMCACHED_SERVICE_PORT", "11211")
-from ietf import __version__
+# Use dummy caches
 CACHES = {
     "default": {
-        "BACKEND": "ietf.utils.cache.LenientMemcacheCache",
-        "LOCATION": f"{MEMCACHED_HOST}:{MEMCACHED_PORT}",
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
         "VERSION": __version__,
         "KEY_PREFIX": "ietf:dt",
-        "KEY_FUNCTION": lambda key, key_prefix, version: (
-            f"{key_prefix}:{version}:{sha384(str(key).encode('utf8')).hexdigest()}"
-        ),
     },
     "sessions": {
-        "BACKEND": "ietf.utils.cache.LenientMemcacheCache",
-        "LOCATION": f"{MEMCACHED_HOST}:{MEMCACHED_PORT}",
-        # No release-specific VERSION setting.
-        "KEY_PREFIX": "ietf:dt",
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
     "htmlized": {
-        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": "/a/cache/datatracker/htmlized",
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "LOCATION": "/var/cache/datatracker/htmlized",
         "OPTIONS": {
-            "MAX_ENTRIES": 100000,  # 100,000
+            "MAX_ENTRIES": 1000,
         },
     },
     "pdfized": {
-        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": "/a/cache/datatracker/pdfized",
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "LOCATION": "/var/cache/datatracker/pdfized",
         "OPTIONS": {
-            "MAX_ENTRIES": 100000,  # 100,000
+            "MAX_ENTRIES": 1000,
         },
     },
     "slowpages": {
-        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": "/a/cache/datatracker/slowpages",
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "LOCATION": "/var/cache/datatracker/",
         "OPTIONS": {
             "MAX_ENTRIES": 5000,
         },

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: rpc-datatracker
 spec:
@@ -8,8 +8,7 @@ spec:
   selector:
     matchLabels:
       app: datatracker
-  strategy:
-    type: Recreate
+  serviceName: "rpc-datatracker"
   template:
     metadata:
       labels:
@@ -35,7 +34,7 @@ spec:
               mountPath: /var/cache/xml2rfc
             - name: dt-cfg
               mountPath: /workspace/ietf/settings_local.py
-              subPath: settings_local.py
+              subPath: datatracker-settings_local.py
           env:
             - name: "CONTAINER_ROLE"
               value: "datatracker"
@@ -86,32 +85,30 @@ spec:
             - name: dt-cfg
               mountPath: /etc/nginx/conf.d/datatracker.conf
               subPath: nginx-datatracker.conf
-        # -----------------------------------------------------
-        # ScoutAPM Container
-        # -----------------------------------------------------
-        - name: rpc-scoutapm
-          image: "scoutapp/scoutapm:version-1.4.0"
-          imagePullPolicy: IfNotPresent
-          # Replace command with one that will shut down on a TERM signal
-          # The ./core-agent start command line is from the scoutapm docker image
+      initContainers:
+        - name: fs-setup
+          image: busybox:stable
           command:
             - "sh"
             - "-c"
-            - >-
-              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
-              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
-              wait $!
-          livenessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
+            - |-
+              cd /a
+              mkdir -p ietfdata/doc/draft/repository &&\
+              mkdir -p www/www6s/staging &&\
+              mkdir -p ietfdata/doc/draft/collection/draft-archive &&\
+              mkdir -p www/www6s/lib/dt/media/photo &&\
+              mkdir -p www/www6s/proceedings &&\
+              mkdir -p www/ietf-ftp/yang/catalogmod &&\
+              mkdir -p www/ietf-ftp/yang/draftmod &&\
+              mkdir -p www/ietf-ftp/yang/ianamod &&\
+              mkdir -p www/ietf-ftp/yang/rfcmod
           securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
             readOnlyRootFilesystem: true
-            runAsUser: 65534 # "nobody" user by default
-            runAsGroup: 65534  # "nogroup" group by default
-      initContainers:
+          volumeMounts:
+            - name: dt-vol
+              mountPath: "/a"
         - name: rpc-migration
           image: "ghcr.io/ietf-tools/datatracker:$APP_IMAGE_TAG"
           env:
@@ -139,10 +136,12 @@ spec:
               mountPath: /var/cache/xml2rfc
             - name: dt-cfg
               mountPath: /workspace/ietf/settings_local.py
-              subPath: settings_local.py
+              subPath: datatracker-settings_local.py
       volumes:
         # To be overriden with the actual shared volume
         - name: dt-vol
+          emptyDir:
+            sizeLimit: "2Gi"
         - name: dt-tmp
           emptyDir:
             sizeLimit: "2Gi"
@@ -154,7 +153,7 @@ spec:
             sizeLimit: "2Gi"
         - name: dt-cfg
           configMap:
-            name: rpc-files-cfgmap
+            name: rpc-dt-files-cfgmap
         - name: nginx-tmp
           emptyDir:
             sizeLimit: "500Mi"

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,9 +3,12 @@ configMapGenerator:
   - name: rpc-files-cfgmap
     files:
       - nginx-logging.conf
-#      - nginx-datatracker.conf
       - nginx-purple.conf
-#      - settings_local.py
+  - name: rpc-dt-files-cfgmap
+    files:
+      - datatracker-settings_local.py
+      - nginx-datatracker.conf
+      - nginx-logging.conf
 resources:
-#  - datatracker.yaml
+  - datatracker.yaml
   - purple.yaml


### PR DESCRIPTION
This drops the datatracker's NFS mount at `/a` and instead sets up just enough of a filesystem to pass the startup checks. 