### PR TITLE
feat: CF service tokens

### DIFF
--- a/datatracker/rpcapi.py
+++ b/datatracker/rpcapi.py
@@ -1,6 +1,7 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
 
 from functools import wraps
+from urllib.parse import urlparse
 import rpcapi_client
 
 from django.conf import settings
@@ -16,6 +17,12 @@ class ApiClient(rpcapi_client.ApiClient):
                 api_key={"ApiKeyAuth": settings.DATATRACKER_RPC_API_TOKEN},
             )
         )
+
+        # Include CF service tokens in the header if configured to do so
+        if getattr(settings, "CF_SERVICE_TOKEN_HOSTS", None) is not None:
+            if urlparse(self.configuration.host).hostname in settings.CF_SERVICE_TOKEN_HOSTS:
+                self.default_headers["CF-Access-Client-Id"] = settings.CF_SERVICE_TOKEN_ID
+                self.default_headers["CF-Access-Client-Secret"] = settings.CF_SERVICE_TOKEN_SECRET
 
 
 def with_rpcapi(f):

--- a/rpcauth/backends.py
+++ b/rpcauth/backends.py
@@ -2,15 +2,122 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import requests
 
 from django.core.exceptions import SuspiciousOperation
 from django.db import IntegrityError
-from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+from django.utils.encoding import smart_str
+from josepy.jws import JWS, Header
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend, import_from_settings
+from requests.auth import HTTPBasicAuth
+from urllib.parse import urlparse
 
-from datatracker.models import DatatrackerPerson
+
+class ServiceTokenOIDCAuthenticationBackend(OIDCAuthenticationBackend):
+    """OIDCAuthenticationBackend that adds Cloudflare service token headers"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.CF_SERVICE_TOKEN_HOSTS = self.get_settings("CF_SERVICE_TOKEN_HOSTS", [])
+        self.CF_SERVICE_TOKEN_ID = self.get_settings("CF_SERVICE_TOKEN_ID", None)
+        self.CF_SERVICE_TOKEN_SECRET = self.get_settings(
+            "CF_SERVICE_TOKEN_SECRET", None
+        )
+
+    def _request_get(self, url, *args, **kwargs):
+        if urlparse(url).hostname in self.CF_SERVICE_TOKEN_HOSTS:
+            if (
+                self.CF_SERVICE_TOKEN_ID is not None
+                and self.CF_SERVICE_TOKEN_SECRET is not None
+            ):
+                extra_headers = {
+                    "CF-Access-Client-ID": self.CF_SERVICE_TOKEN_ID,
+                    "CF-Access-Client-Secret": self.CF_SERVICE_TOKEN_SECRET,
+                }
+                kwargs["headers"] = kwargs.get("headers", {}) | extra_headers
+        return requests.get(url, *args, **kwargs)
+
+    def _request_post(self, url, *args, **kwargs):
+        if urlparse(url).hostname in self.CF_SERVICE_TOKEN_HOSTS:
+            if (
+                self.CF_SERVICE_TOKEN_ID is not None
+                and self.CF_SERVICE_TOKEN_SECRET is not None
+            ):
+                extra_headers = {
+                    "CF-Access-Client-ID": self.CF_SERVICE_TOKEN_ID,
+                    "CF-Access-Client-Secret": self.CF_SERVICE_TOKEN_SECRET,
+                }
+                kwargs["headers"] = kwargs.get("headers", {}) | extra_headers
+        return requests.post(url, *args, **kwargs)
+
+    def retrieve_matching_jwk(self, token):
+        """Get the signing key by exploring the JWKS endpoint of the OP."""
+        response_jwks = self._request_get(
+            self.OIDC_OP_JWKS_ENDPOINT,
+            verify=self.get_settings("OIDC_VERIFY_SSL", True),
+            timeout=self.get_settings("OIDC_TIMEOUT", None),
+            proxies=self.get_settings("OIDC_PROXY", None),
+        )
+        response_jwks.raise_for_status()
+        jwks = response_jwks.json()
+
+        # Compute the current header from the given token to find a match
+        jws = JWS.from_compact(token)
+        json_header = jws.signature.protected
+        header = Header.json_loads(json_header)
+
+        key = None
+        for jwk in jwks["keys"]:
+            if import_from_settings("OIDC_VERIFY_KID", True) and jwk[
+                "kid"
+            ] != smart_str(header.kid):
+                continue
+            if "alg" in jwk and jwk["alg"] != smart_str(header.alg):
+                continue
+            key = jwk
+        if key is None:
+            raise SuspiciousOperation("Could not find a valid JWKS.")
+        return key
+
+    def get_token(self, payload):
+        """Return token object as a dictionary."""
+
+        auth = None
+        if self.get_settings("OIDC_TOKEN_USE_BASIC_AUTH", False):
+            # When Basic auth is defined, create the Auth Header and remove secret from payload.
+            user = payload.get("client_id")
+            pw = payload.get("client_secret")
+
+            auth = HTTPBasicAuth(user, pw)
+            del payload["client_secret"]
+
+        response = self._request_post(
+            self.OIDC_OP_TOKEN_ENDPOINT,
+            data=payload,
+            auth=auth,
+            verify=self.get_settings("OIDC_VERIFY_SSL", True),
+            timeout=self.get_settings("OIDC_TIMEOUT", None),
+            proxies=self.get_settings("OIDC_PROXY", None),
+        )
+        self.raise_token_response_error(response)
+        return response.json()
+
+    def get_userinfo(self, access_token, id_token, payload):
+        """Return user details dictionary. The id_token and payload are not used in
+        the default implementation, but may be used when overriding this method"""
+
+        user_response = self._request_get(
+            self.OIDC_OP_USER_ENDPOINT,
+            headers={"Authorization": "Bearer {0}".format(access_token)},
+            verify=self.get_settings("OIDC_VERIFY_SSL", True),
+            timeout=self.get_settings("OIDC_TIMEOUT", None),
+            proxies=self.get_settings("OIDC_PROXY", None),
+        )
+        user_response.raise_for_status()
+        return user_response.json()
 
 
-class RpcOIDCAuthBackend(OIDCAuthenticationBackend):
+class RpcOIDCAuthBackend(ServiceTokenOIDCAuthenticationBackend):
     """Customized OIDC auth backend
 
     Assumes the datatracker makes the following claims:

--- a/rpcauth/backends.py
+++ b/rpcauth/backends.py
@@ -31,7 +31,7 @@ class ServiceTokenOIDCAuthenticationBackend(OIDCAuthenticationBackend):
                 and self.CF_SERVICE_TOKEN_SECRET is not None
             ):
                 extra_headers = {
-                    "CF-Access-Client-ID": self.CF_SERVICE_TOKEN_ID,
+                    "CF-Access-Client-Id": self.CF_SERVICE_TOKEN_ID,
                     "CF-Access-Client-Secret": self.CF_SERVICE_TOKEN_SECRET,
                 }
                 kwargs["headers"] = kwargs.get("headers", {}) | extra_headers
@@ -44,7 +44,7 @@ class ServiceTokenOIDCAuthenticationBackend(OIDCAuthenticationBackend):
                 and self.CF_SERVICE_TOKEN_SECRET is not None
             ):
                 extra_headers = {
-                    "CF-Access-Client-ID": self.CF_SERVICE_TOKEN_ID,
+                    "CF-Access-Client-Id": self.CF_SERVICE_TOKEN_ID,
                     "CF-Access-Client-Secret": self.CF_SERVICE_TOKEN_SECRET,
                 }
                 kwargs["headers"] = kwargs.get("headers", {}) | extra_headers

--- a/rpctracker/settings/production.py
+++ b/rpctracker/settings/production.py
@@ -57,6 +57,15 @@ OIDC_OP_USER_ENDPOINT = os.environ.get(
 )
 
 
+# Config for Cloudflare service token auth
+_CF_SERVICE_TOKEN_HOSTS = os.environ.get("PURPLE_SERVICE_TOKEN_HOSTS", None)
+if _CF_SERVICE_TOKEN_HOSTS is not None:
+    # include token id/secret headers for these hosts
+    CF_SERVICE_TOKEN_HOSTS = _multiline_to_list(_CF_SERVICE_TOKEN_HOSTS)
+    CF_SERVICE_TOKEN_ID = os.environ.get("PURPLE_SERVICE_TOKEN_ID", None)
+    CF_SERVICE_TOKEN_SECRET = os.environ.get("PURPLE_SERVICE_TOKEN_SECRET", None)
+
+
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 


### PR DESCRIPTION
This adds cloudflare service token headers to OIDC back channel requests to the OP (I.e., datatracker) and to datatracker API calls. Tries to be paranoid about leaking the tokens on requests to other hosts. For staging, the `PURPLE_SERVICE_TOKEN_HOSTS` will contain only the hostname for the staging datatracker-rpc instance.