### PR TITLE
refactor: rename 'date' to 'time' in history APIs

### DIFF
--- a/client/components/DocumentComment.vue
+++ b/client/components/DocumentComment.vue
@@ -42,8 +42,8 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
             </span>
           </span>
           <time
-            v-if="comment.lastEdit.date"
-            :datetime="comment.lastEdit.date.toISOString()"
+            v-if="comment.lastEdit.time"
+            :datetime="comment.lastEdit.time.toISOString()"
             class="text-gray-500"
           >
             {{ comment.lastEditAgo }}

--- a/client/components/DocumentComments.vue
+++ b/client/components/DocumentComments.vue
@@ -75,7 +75,7 @@ const cookedComments = computed(() => {
     props.commentList?.results?.map((comment) => ({
       ...comment,
       ago: comment.time ? DateTime.fromJSDate(comment.time).toRelative() : undefined,
-      lastEditAgo: comment.lastEdit?.date ? DateTime.fromJSDate(comment.lastEdit.date).toRelative() : undefined
+      lastEditAgo: comment.lastEdit?.time ? DateTime.fromJSDate(comment.lastEdit.time).toRelative() : undefined
     })) ?? []
   )
 })

--- a/client/pages/docs/[id]/index.vue
+++ b/client/pages/docs/[id]/index.vue
@@ -111,8 +111,8 @@
               <tbody class="divide-y divide-gray-200">
               <tr v-for="entry of draft?.history ?? []" :key="entry.id">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium sm:pl-6">
-                  <time :datetime="DateTime.fromJSDate(entry.date).toString()">
-                    {{ DateTime.fromJSDate(entry.date).toLocaleString(DateTime.DATE_MED) }}
+                  <time :datetime="DateTime.fromJSDate(entry.time).toString()">
+                    {{ DateTime.fromJSDate(entry.time).toLocaleString(DateTime.DATE_MED) }}
                   </time>
                 </td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm">

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -115,7 +115,7 @@ class HistorySerializer(serializers.Serializer):
     """Serialize a HistoricalRecord"""
 
     id = serializers.IntegerField()
-    date = serializers.DateTimeField()
+    time = serializers.DateTimeField(source="date")
     by = UserSerializer()
     desc = serializers.CharField()
 
@@ -137,7 +137,7 @@ class HistoryLastEditSerializer(serializers.Serializer):
     """Serialize the most recent change in a HistoricalRecord"""
 
     by = UserSerializer(source="history_user", read_only=True)
-    date = serializers.DateTimeField(source="history_date", read_only=True)
+    time = serializers.DateTimeField(source="history_date", read_only=True)
 
     def __init__(self, instance=None, data=empty, **kwargs):
         if not kwargs.get("read_only", True):


### PR DESCRIPTION
Keeps the API naming consistent with our own models, which use 'time' to name DateTimes.