### PR TITLE
fix: tailwind globbing 

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -2,7 +2,12 @@ import formsPlugin from '@tailwindcss/forms'
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [],
+  content: [
+    "./layouts/*.{html,ts,vue}",
+    "./pages/*.{html,ts,vue}",
+    "./utilities/*.{html,ts,vue}",
+    "./components/*.{html,ts,vue}",
+  ],
   darkMode: 'class',
   plugins: [
     formsPlugin


### PR DESCRIPTION
## fix

* tailwind's config wasn't looking into our `utilities/*.ts` files so it wasn't generating styles correctly for RPC labels (badges/pills)

(more generally we might want to consider visual regression tests to identify this)
