### PR TITLE
fix: on put and patch for author, update only validated fields, not order

### DIFF
--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -180,6 +180,10 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "datatracker_person"]
 
+    def update(self, instance, validated_data):
+        RfcAuthor.objects.filter(pk=instance.pk).update(**validated_data)
+        return RfcAuthor.objects.get(pk=instance.pk)
+
 
 class CreateRfcAuthorSerializer(RfcAuthorSerializer):
     # person_id is not a field on the model - remove it from validated_data


### PR DESCRIPTION
try to avoid a full update on all fields of author on patch/put, but only update the fields that were send