### PR TITLE
fix: preserve linebreaks from DB in textbox

### DIFF
--- a/client/app/components/DocumentComment.vue
+++ b/client/app/components/DocumentComment.vue
@@ -56,7 +56,7 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
         </button>
       </div>
     </div>
-    <p v-if="!isEditing" class="text-sm leading-6 text-gray-500">
+    <p v-if="!isEditing" class="text-sm leading-6 text-gray-500 whitespace-pre-wrap">
       {{ comment.comment }}
     </p>
     <div v-else>


### PR DESCRIPTION
Display text with newlines

<img width="856" height="869" alt="image" src="https://github.com/user-attachments/assets/80408db9-ea53-4bbd-998d-bff85d6fcc0c" />
