### PR TITLE
chore(dev): use imported DB dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ logs
 .DS_Store
 .fleet
 .idea
-.gitkeep
 
 # Local env files
 .env
@@ -38,4 +37,4 @@ __pycache__
 client/app/purple_client
 /static
 purple_api.yaml
-
+/purple.dump

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This step is required if you need a populated database to work with. In addition
 1. Open a shell _on the host_ (not in the docker container) and navigate to the project root directory.
 2. Run `./refresh_xfer_dump.sh`. This will prompt you to authenticate with Azure and download the most recent xfer dump.
 
-To return to an empty DB as a starting point, remove the `.db-dump/purple.dump` file this downloaded and rebuild your docker environment.
+To return to an empty DB as a starting point, remove the `purple.dump` and rebuild your docker environment.
 
 ## Using VS Code
 
@@ -114,12 +114,12 @@ After obtaining the new database dump, on the host (i.e., _outside_ the docker c
 ```sh
 ./rebuild_db_container.sh
 ```
-This will destroy your db container and its data, then build a new one using the dump found in `.db-dump/purple.dump`. If there is no such file, an empty database will be created.
+This will destroy your db container and its data, then build a new one using the dump found in `purple.dump`. If there is no such file, an empty database will be created.
 
 ### Returning to an empty database
 
 To start over with an empty database after using an rfced-xfer dump
-1. Remove the file `.db-dump/purple.dump`
+1. Remove the file `purple.dump`
 2. Follow the steps to [load a new database dump](#loading-a-new-database-dump)
 3. Restart your docker environment or run `./manage.py migrate` in your app container.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,14 @@ services:
       dockerfile: docker/db.Dockerfile
     volumes:
       - postgresdb-data:/var/lib/postgresql/data
+      - .:/workspace
     restart: unless-stopped
     environment:
       - POSTGRES_DB=rpctools
       - POSTGRES_USER=rpc
       - POSTGRES_PASSWORD=abcd1234
       - POSTGRES_HOST_AUTH_METHOD=trust
+      - DUMPFILE=/workspace/purple.dump
 
   app:
     build:

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,29 +1,6 @@
-# =====================
-# --- Builder Stage ---
-# =====================
-FROM postgres:17 AS builder
-
-ENV POSTGRES_PASSWORD=abcd1234
-ENV POSTGRES_USER=rpc
-ENV POSTGRES_DB=rpctools
-ENV POSTGRES_HOST_AUTH_METHOD=trust
-ENV PGDATA=/data
-
-COPY docker/scripts/db-import.sh /docker-entrypoint-initdb.d/
-COPY .db-dump/* /db-dumps/
-
-RUN ["sed", "-i", "s/exec \"$@\"/echo \"skipping...\"/", "/usr/local/bin/docker-entrypoint.sh"]
-RUN ["/usr/local/bin/docker-entrypoint.sh", "postgres"]
-
-# ===================
-# --- Final Image ---
-# ===================
 FROM postgres:17
 LABEL maintainer="IETF Tools Team <tools-discuss@ietf.org>"
 
-COPY --from=builder /data $PGDATA
+COPY docker/scripts/db-import.sh /docker-entrypoint-initdb.d/
 
-ENV POSTGRES_PASSWORD=abcd1234
-ENV POSTGRES_USER=rpc
-ENV POSTGRES_DB=rpctools
-ENV POSTGRES_HOST_AUTH_METHOD=trust
+ENV DUMPFILE=""

--- a/docker/scripts/db-import.sh
+++ b/docker/scripts/db-import.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-set -e -o pipefail
-DUMPFILE=/db-dumps/purple.dump
+set -e -x -o pipefail
 
 echo "Drop DB if it exists..."
 dropdb -U "$POSTGRES_USER" --if-exists "$POSTGRES_DB"
@@ -8,11 +7,13 @@ dropdb -U "$POSTGRES_USER" --if-exists "$POSTGRES_DB"
 echo "Create empty DB..."
 createdb -U "$POSTGRES_USER" -T template0 "$POSTGRES_DB"
 
-if [ -f "$DUMPFILE" ]; then
+if [ -z "$DUMPFILE" ]; then
+    echo "DUMPFILE not set, starting with an empty database."
+elif [ -f "$DUMPFILE" ]; then
     echo "Import DB dump into $POSTGRES_DB..."
     pg_restore --clean --if-exists --no-owner -U "$POSTGRES_USER" -d "$POSTGRES_DB" "$DUMPFILE"
 else
-    echo "No file to import, skipping..."
+    echo "No file to import, starting with an empty database."
 fi
 
 echo "Done!"

--- a/rebuild_db_container.sh
+++ b/rebuild_db_container.sh
@@ -8,9 +8,6 @@ echo "Removing db container and volume..."
 docker compose rm -fv db
 docker volume rm -f purple_postgresdb-data
 
-echo "Building new db image..."
-docker compose build db
-
 echo "Creating db container..."
 docker compose create db
 

--- a/refresh_xfer_dump.sh
+++ b/refresh_xfer_dump.sh
@@ -4,4 +4,4 @@ az login
 
 echo "Fetching latest xfer dump..."
 LATESTDBKEY=$(az storage blob list -c database --prefix purple/purple --query "[-1:].name | [0]" --out tsv)
-az storage blob download -c database -n $LATESTDBKEY -f .db-dump/purple.dump -o none
+az storage blob download -c database -n $LATESTDBKEY -f purple.dump -o none


### PR DESCRIPTION
Refactors the dev db container to optionally load a database dump instead of starting with an empty database. When building the image for the db container, copies `.db-dump/purple.dump` into the image and uses this to create the initial database when the container starts.

 and adds two scripts:
* `refresh_xfer_dump.sh` - retrieves the latest rfced-xfer database dump
* `rebuild_db_container.sh` - removes the existing db container and builds a new one, updating the contents to match whatever is in `.db-dump/purple.dump`

The database needs to match the data in the datatracker instance supporting the purple dev instance. That is not yet automated.