### PR TITLE
fix: for patches on assignments, set state

### DIFF
--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -211,10 +211,9 @@ class AssignmentSerializer(serializers.ModelSerializer):
 
     def to_internal_value(self, data):
         # For partial updates, add "state" field to avoid constraint violations
-        if getattr(self, 'partial', False) and self.instance:
-            if 'state' not in data:
-                existing_value = getattr(self.instance, 'state')
-                data['state'] = existing_value
+        if getattr(self, "partial", False) and self.instance:
+            if "state" not in data:
+                data["state"] = self.instance.state
 
         return super().to_internal_value(data)
 


### PR DESCRIPTION
patch on assignment is currently broken if "state" is not included in request.
This is due to the constraint condition `condition=~models.Q(state__in=ASSIGNMENT_INACTIVE_STATES),`

The fix will make sure it is set with current value if not present
