### PR TITLE
fix: timespent as hours

### DIFF
--- a/client/app/components/AssignmentModal.vue
+++ b/client/app/components/AssignmentModal.vue
@@ -314,4 +314,5 @@ const changeReason = (action: ActionWithdrawn, e: Event): void => {
   assert(e.target instanceof HTMLInputElement)
   action.reason = e.target.value
 }
+
 </script>

--- a/client/app/utils/form.test.ts
+++ b/client/app/utils/form.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from 'vitest'
+import { durationStringToHours, hoursToDurationString } from './form'
+
+test('durationStringToHours', () => {
+  expect(durationStringToHours('00:00:00')).toBe(0)
+  expect(durationStringToHours('01:00:00')).toBe(1)
+  expect(durationStringToHours('23:00:00')).toBe(23)
+  expect(durationStringToHours('1 00:00:00')).toBe(24)
+  expect(durationStringToHours('24 00:00:00')).toBe(576)
+  expect(durationStringToHours('23 00:00:00')).toBe(552)
+  expect(durationStringToHours('1:23 00:00:00')).toBe(1272)
+
+  // fractions
+  expect(durationStringToHours('01:15:00')).toBe(1.25)
+  expect(durationStringToHours('70:15:00')).toBe(70.25)
+})
+
+test('hoursToDurationString', () => {
+  expect(hoursToDurationString(0)).toBe('0 00:00:00')
+  expect(hoursToDurationString(1)).toBe('0 01:00:00')
+  expect(hoursToDurationString(24)).toBe('1 00:00:00')
+
+  // fractions
+  expect(hoursToDurationString(1.25)).toBe('0 01:15:00')
+  expect(hoursToDurationString(70.25)).toBe('2 22:15:00')
+})
+
+test('durationStringToHours(hoursToDurationString(h))', () => {
+  // ensure the converters are reversible
+  expect(durationStringToHours(hoursToDurationString(1))).toBe(1)
+  expect(durationStringToHours(hoursToDurationString(2))).toBe(2)
+  expect(durationStringToHours(hoursToDurationString(25))).toBe(25)
+  expect(durationStringToHours(hoursToDurationString(100))).toBe(100)
+})

--- a/client/app/utils/form.ts
+++ b/client/app/utils/form.ts
@@ -1,0 +1,25 @@
+
+import { Duration } from 'luxon'
+import type { DurationLike  } from 'luxon'
+
+export const durationStringToHours = (durationString: string | undefined): number => {
+  if(durationString === undefined ) return 0
+  const [seconds, minutes, hours, days, months, years] = durationString.split(/[ :]/).reverse()
+  const durationLike: DurationLike = {
+    years: years ? parseFloat(years) : 0,
+    months: months ? parseFloat(months) : 0,
+    days: days ? parseFloat(days) : 0,
+    hours:  hours ? parseFloat(hours) : 0,
+    minutes: minutes ? parseFloat(minutes) : 0,
+    seconds: seconds ? parseFloat(seconds) : 0,
+  }
+  const duration = Duration.fromDurationLike(durationLike)
+  return duration.as('hours')
+}
+
+const HOURS_TO_MILLISECONDS_RATIO = 60 * 60 * 1000
+
+export const hoursToDurationString = (hours: number): string => {
+  const duration = Duration.fromMillis(hours * HOURS_TO_MILLISECONDS_RATIO)
+  return duration.toFormat('d hh:mm:ss')
+}

--- a/client/app/utils/url.test.ts
+++ b/client/app/utils/url.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest'
 import { isInternalLink } from './url'
 
-test('isInternalLink', ()=> {
+test('isInternalLink', () => {
   expect(isInternalLink('/something')).toBeTruthy()
   expect(isInternalLink('https://example.com')).toBeFalsy()
 })


### PR DESCRIPTION
## fix

* previously the user had to type time spent in the format `d hh:mm:ss` but now they can just enter hours and  the frontend will convert it. There are tests.