### PR TITLE
feat: iana actions (prototype)

### DIFF
--- a/client/app/components/IANAActions.vue
+++ b/client/app/components/IANAActions.vue
@@ -1,0 +1,19 @@
+<template>
+  <ul class="flex flex-col gap-2">
+    <li v-for="ianaAction in IANAActionsEntries">
+      <RpcRadio name="ianaAction" :value="ianaAction[0]" :checked="ianaAction[0] === ianaChoice" :label="ianaAction[1]" @change="handleChange" />
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { type IANAActionsEnum, IANAActionsEntries } from '../utils/iana'
+
+const ianaChoice = defineModel<IANAActionsEnum>({ required: true })
+
+const handleChange = (e: Event) => {
+  const { target } = e
+  assert(target instanceof HTMLInputElement)
+  ianaChoice.value = target.value as IANAActionsEnum
+}
+</script>

--- a/client/app/components/IANAActionsModal.vue
+++ b/client/app/components/IANAActionsModal.vue
@@ -1,0 +1,43 @@
+<template>
+  <form class="py-2 px-4 bg-white text-black dark:bg-black dark:text-white h-full">
+    <Heading :heading-level="2" class="pb-3 pt-5">IANA Actions</Heading>
+    <IANAActions :heading-level="3" v-model="ianaChoice" />
+    <div class="border-t-2 border-gray-400 mt-5 pt-2 flex justify-end">
+      <BaseButton btn-type="default" @click="handleSave">Save</BaseButton>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { overlayModalKey } from '~/providers/providerKeys';
+import { IANAActionsEntries, type IANAActionsEnum } from '../utils/iana'
+
+type Props = {
+  name: string
+  ianaAction: IANAActionsEnum
+  onSuccess: () => Promise<void>
+}
+
+const props = defineProps<Props>()
+
+const defaultOption = IANAActionsEntries?.[0]?.[0]
+if (!defaultOption) {
+  throw Error('Expected default IANA option')
+}
+
+const ianaChoice = ref<IANAActionsEnum>(props.ianaAction)
+
+const overlayModalKeyInjection = inject(overlayModalKey)
+
+if (!overlayModalKeyInjection) {
+  throw Error('Expected injection of overlayModalKey')
+}
+
+const { closeOverlayModal } = overlayModalKeyInjection
+
+const handleSave = async () => {
+  alert(`TODO: save ${ianaChoice.value} to ${props.name}`)
+  await props.onSuccess() // trigger data reload
+  closeOverlayModal()
+}
+</script>

--- a/client/app/components/IANAActionsSummary.vue
+++ b/client/app/components/IANAActionsSummary.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="flex flex-row justify-between items-center">
+    <span>
+      IANA Action: <span class="font-bold">{{ IANAActionOptions[props.ianaAction] }}</span>
+    </span>
+    <BaseButton btn-type="default" @click="openModal">Edit</BaseButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { overlayModalKey } from '~/providers/providerKeys';
+import { type IANAActionsEnum, IANAActionOptions } from '../utils/iana'
+import IANAActionsModal from './IANAActionsModal.vue'
+
+type Props = {
+  name: string
+  ianaAction: IANAActionsEnum
+  onSuccess: () => Promise<void>
+}
+
+const props = defineProps<Props>()
+
+const overlayModalKeyInjection = inject(overlayModalKey)
+
+if (!overlayModalKeyInjection) {
+  throw Error('Expected injection of overlayModalKey')
+}
+
+const { openOverlayModal } = overlayModalKeyInjection
+
+const openModal = () => {
+ openOverlayModal({
+    component: IANAActionsModal,
+    componentProps: {
+      name: props.name,
+      ianaAction: props.ianaAction,
+      onSuccess: props.onSuccess
+    },
+    mode: 'side',
+  }).catch(e => {
+    if (e === undefined) {
+      // ignore... it's just signalling that the modal has closed
+    } else {
+      console.error(e)
+      throw e
+    }
+  })
+}
+</script>

--- a/client/app/pages/docs/[id]/index.vue
+++ b/client/app/pages/docs/[id]/index.vue
@@ -126,6 +126,11 @@
           </DocumentDependencies>
         </div>
 
+        <BaseCard class="lg:col-span-full grid place-items-stretch">
+          <IANAActionsSummary v-if="rawRfcToBe && rawRfcToBe.name" iana-action="iana-no-actions"
+            :on-success="rfcToBeReload" :name="rawRfcToBe.name" />
+        </BaseCard>
+
         <div class="lg:col-span-full">
           <DocumentFinalReviews :heading-level="4" :name="draftName" :on-success="() => commentsReload()" />
         </div>
@@ -224,7 +229,7 @@ const {
   refresh: historyRefresh
 } = await useHistoryForDraft(draftName.value)
 
-const { data: rawRfcToBe, error: rawRfcToBeError, status: rfcToBeStatus } = await useAsyncData(
+const { data: rawRfcToBe, error: rawRfcToBeError, status: rfcToBeStatus, refresh: rfcToBeReload } = await useAsyncData(
   () => `draft-${draftName.value}`,
   () => api.documentsRetrieve({ draftName: draftName.value }),
   {

--- a/client/app/pages/docs/import.vue
+++ b/client/app/pages/docs/import.vue
@@ -110,6 +110,10 @@
               </div>
             </div>
           </div>
+          <fieldset>
+            <legend class="block text-sm font-medium leading-6 text-gray-900">IANA Actions</legend>
+            <IANAActions v-model="state.ianaAction" />
+          </fieldset>
           <!-- Comments -->
           <div v-if="!backendPending" class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
             <div class="sm:col-span-4 space-y-4">
@@ -145,6 +149,7 @@ import { DateTime } from 'luxon'
 import humanizeDuration from 'humanize-duration'
 import type { PaginatedDocumentCommentList, Name } from '~/purple_client'
 import { computed } from 'vue'
+import { type IANAActionsEnum } from '../../utils/iana'
 
 const route = useRoute()
 const api = useApi()
@@ -154,12 +159,13 @@ const currentTime = useCurrentTime()
 const today = computed(() => currentTime.value.startOf('day'))
 
 type State = {
-  boilerplate: Name | null,
-  sourceFormat: Name | null,
-  stdLevel: Name | null,
-  stream: Name | null,
-  deadline: string | null,
+  boilerplate: Name | null
+  sourceFormat: Name | null
+  stdLevel: Name | null
+  stream: Name | null
+  deadline: string | null
   labels: number[]
+  ianaAction: IANAActionsEnum
 }
 
 const state = reactive<State>({
@@ -168,7 +174,8 @@ const state = reactive<State>({
   stdLevel: null,
   stream: null,
   deadline: today.value.plus({ weeks: 6 }).toISODate(),
-  labels: []
+  labels: [],
+  ianaAction: 'iana-no-actions'
 })
 
 // COMPUTED

--- a/client/app/utils/iana.ts
+++ b/client/app/utils/iana.ts
@@ -1,0 +1,11 @@
+export const IANAActionOptions = {
+  "iana-no-actions": 'This document has no IANA actions',
+  'iana-waiting-on': 'IANA has not completed actions in draft',
+  'iana-completed': 'IANA has completed actions in draft',
+  'iana-registry-changes-needed': 'Changes to registries are required due to RFC edits',
+  'iana-reconciled-changes': 'IANA has reconciled changes between draft and RFC'
+} as const
+
+export type IANAActionsEnum = keyof typeof IANAActionOptions
+
+export const IANAActionsEntries = Object.entries(IANAActionOptions) as [IANAActionsEnum, string][]


### PR DESCRIPTION
## feat

* IANA actions. The enum is currently hardcoded and it's not wired up to an API. This is just doing the boilerplate UI ahead of the API being available.

**screenshots**
*doc info page*
<img width="1074" height="275" alt="Screenshot_2025-11-26_13-13-22" src="https://github.com/user-attachments/assets/99989957-309b-48d1-9926-4fbee1d8a398" />

*modal*
<img width="559" height="275" alt="Screenshot_2025-11-26_13-13-27" src="https://github.com/user-attachments/assets/523a9da4-a84b-4fcf-83cf-dd23af11f6c4" />

*ingest*
<img width="475" height="247" alt="Screenshot_2025-11-26_13-14-47" src="https://github.com/user-attachments/assets/682f754b-ac76-4940-9be6-390b5e02a4bb" />

