### PR TITLE
feat: approval logs (public comments)

### DIFF
--- a/client/app/components/DocumentApprovalLog.vue
+++ b/client/app/components/DocumentApprovalLog.vue
@@ -3,34 +3,22 @@ History feed component
 Based on https://tailwindui.com/components/application-ui/lists/feeds#component-81e5ec57a92ddcadaa913e7bb68336fe
 -->
 <template>
-  <div
-    :class="[
-      props.isLastComment ? 'h-6' : '-bottom-6',
-      'absolute left-0 top-0 flex w-6 justify-center'
-    ]"
-  >
+  <div :class="[
+    props.isLast ? 'h-6' : '-bottom-6',
+    'absolute left-0 top-0 flex w-6 justify-center'
+  ]">
   </div>
-  <img
-    v-if="approvalLogMessage.by?.picture"
-    :src="approvalLogMessage.by.picture"
-    alt=""
-    class="relative mt-3 h-6 w-6 flex-none rounded-full bg-gray-50"
-  />
+  <img v-if="approvalLogMessage.by?.picture" :src="approvalLogMessage.by.picture" alt=""
+    class="relative mt-3 h-6 w-6 flex-none rounded-full bg-gray-50" />
   <div class="flex-auto rounded-md p-3 ring-1 ring-inset ring-gray-200">
     <div class="flex justify-between gap-x-4">
       <div v-if="approvalLogMessage.by" class="py-0.5 text-xs leading-5 text-gray-500">
-        <span
-          class="font-medium text-gray-900"
-          :title="approvalLogMessage.by.rpcperson ? `${approvalLogMessage.by.name} (user #${approvalLogMessage.by.rpcperson})` : undefined"
-        >
+        <span class="font-medium text-gray-900"
+          :title="approvalLogMessage.by.rpcperson ? `${approvalLogMessage.by.name} (user #${approvalLogMessage.by.rpcperson})` : undefined">
           {{ approvalLogMessage.by.name }}
         </span>
         commented
-        <time
-          v-if="approvalLogMessage.time"
-          :datetime="approvalLogMessage.time.toISOString()"
-          class="text-gray-500"
-        >
+        <time v-if="approvalLogMessage.time" :datetime="approvalLogMessage.time.toISOString()" class="text-gray-500">
           {{ approvalLogMessage.ago }}
         </time>
       </div>
@@ -44,13 +32,9 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
       {{ approvalLogMessage.logMessage }}
     </p>
     <div v-else>
-      <textarea
-        v-model="editApprovalLogMessage"
-        rows="3"
-        name="comment"
+      <textarea v-model="editApprovalLogMessage" rows="3" name="comment"
         class="block w-full resize-none border-1 bg-transparent text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
-        placeholder="Edit approval log message..."
-      />
+        placeholder="Edit approval log message..." />
       <div class="flex justify-between pt-1">
         <BaseButton btn-type="cancel" @click="isEditing = false" :disabled="isUpdating">Cancel</BaseButton>
         <BaseButton btn-type="default" @click="handleUpdateApprovalLogMessage" :disabled="isUpdating">
@@ -63,8 +47,8 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
 </template>
 
 <script setup lang="ts">
-import type {ApprovalLogMessage } from '~/purple_client'
-import {snackbarForErrors} from '~/utils/snackbar'
+import type { ApprovalLogMessage } from '~/purple_client'
+import { snackbarForErrors } from '~/utils/snackbar'
 
 type Props = {
   draftName: string
@@ -73,8 +57,8 @@ type Props = {
     ago?: string | null
     lastEditAgo?: string | null
   }
-  isLastComment: boolean,
-  reloadComments: () => Promise<void>
+  isLast: boolean,
+  reload: () => Promise<void>
 }
 
 const props = defineProps<Props>()
@@ -85,7 +69,7 @@ const isUpdating = ref(false)
 const editApprovalLogMessage = ref(props.approvalLogMessage.logMessage)
 
 watch(() => props.approvalLogMessage, (newValue, oldValue) => {
-  if(newValue.logMessage !== oldValue.logMessage) {
+  if (newValue.logMessage !== oldValue.logMessage) {
     // then a new comment has been saved and we're receiving the props,
     // so clobber the editComment ref with the current value
     editApprovalLogMessage.value = newValue.logMessage
@@ -106,7 +90,7 @@ const handleUpdateApprovalLogMessage = async () => {
     await api.documentsApprovalLogsPartialUpdate({
       draftName: props.draftName,
       id: props.approvalLogMessage.id!,
-      patchedApprovalLogMessageRequest    : {
+      patchedApprovalLogMessageRequest: {
         logMessage: editApprovalLogMessage.value
       }
     })
@@ -116,8 +100,8 @@ const handleUpdateApprovalLogMessage = async () => {
       title: 'Comment updated successfully',
       text: ''
     })
-    await props.reloadComments()
-  } catch(error: unknown) {
+    await props.reload()
+  } catch (error: unknown) {
     snackbarForErrors({ snackbar, error, defaultTitle: "Problem updating comment" })
   }
   isUpdating.value = false

--- a/client/app/components/DocumentApprovalLogs.vue
+++ b/client/app/components/DocumentApprovalLogs.vue
@@ -23,7 +23,8 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
         </span>
       </h1>
       <button
-        @click="props.reloadComments"
+        type="button"
+        @click="props.reload"
         class="border ml-3 border-gray-200 px-2 py-1"
       >
         Try again
@@ -32,21 +33,20 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
     <div v-if="props.isLoading" class="text-center">
       <Icon name="ei:spinner-3" size="3.5em" class="animate-spin mb-3" />
     </div>
-    <div v-if="props.commentList?.count === 0" class="text-center text-sm mt-4 mb-2">
-      <p class="italic text-gray-500">no comments</p>
-
+    <div v-if="props.commentList && props.commentList.length === 0" class="text-center text-sm mt-4 mb-2">
+      <p class="italic text-gray-500">no approval logs</p>
     </div>
     <ul role="list" class="space-y-6">
       <li
-        v-for="(comment, commentIndex) in cookedComments"
-        :key="comment.id"
+        v-for="(approvalLogMessage, commentIndex) in cookedApprovalLogMessages"
+        :key="approvalLogMessage.id"
         class="relative flex gap-x-4"
       >
-        <DocumentComment
+        <DocumentApprovalLog
           :draft-name="props.draftName"
-          :comment="comment"
-          :is-last-comment="commentIndex === cookedComments.length"
-          :reload-comments="reloadComments"
+          :approvalLogMessage="approvalLogMessage"
+          :is-last="commentIndex === cookedApprovalLogMessages.length"
+          :reload="props.reload"
         />
       </li>
     </ul>
@@ -63,12 +63,12 @@ type Props = {
   isLoading: boolean
   error?: NuxtError | null
   commentList?: ApprovalLogMessage[] | null | undefined
-  reloadComments: () => Promise<void>
+  reload: () => Promise<void>
 }
 
 const props = defineProps<Props>()
 
-const cookedComments = computed(() => {
+const cookedApprovalLogMessages = computed(() => {
   return (
     props.commentList?.map((comment) => ({
       ...comment,

--- a/client/app/components/DocumentComments.vue
+++ b/client/app/components/DocumentComments.vue
@@ -23,6 +23,7 @@ Based on https://tailwindui.com/components/application-ui/lists/feeds#component-
         </span>
       </h1>
       <button
+        type="button"
         @click="props.reloadComments"
         class="border ml-3 border-gray-200 px-2 py-1"
       >

--- a/client/app/components/RpcApprovalLogTextarea.vue
+++ b/client/app/components/RpcApprovalLogTextarea.vue
@@ -1,0 +1,110 @@
+<!-- based on https://tailwindui.com/components/application-ui/forms/textareas#component-784309f82e9913989c2196a2d47eff4a -->
+<template>
+  <div class="flex items-start space-x-4">
+    <div class="flex-shrink-0">
+      <Icon name="mdi:comment-text-outline" class="mr-1" />
+    </div>
+    <div class="min-w-0 flex-1">
+      <form action="#" class="relative" @submit.prevent="handleSubmit">
+        <div
+          class="overflow-hidden rounded-lg shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600"
+        >
+          <label for="approvalLog" class="sr-only">Add your approval log</label>
+          <textarea
+            v-model="logMessage"
+            rows="3"
+            name="approvalLog"
+            id="approvalLog"
+            class="block w-full resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
+            placeholder="Add your approval log..."
+          />
+          <!-- Spacer element to match the height of the toolbar -->
+          <div class="py-2" aria-hidden="true">
+            <!-- Matches height of button in toolbar (1px border + 36px content height) -->
+            <div class="py-px">
+              <div class="h-9" />
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="absolute inset-x-0 bottom-0 flex justify-end py-2 pl-3 pr-2"
+        >
+          <button
+            type="submit"
+            class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            :disabled="isSubmitting"
+          >
+            <Icon
+              v-if="isSubmitting"
+              name="ei:spinner-3"
+              size="1.1em"
+              class="animate-spin mr-1"
+            />
+            Add Approval Log (public)
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { localStorageWrapper } from '~/utils/localstorage'
+import { snackbarForErrors } from '~/utils/snackbar'
+
+type Props = {
+  draftName: string
+  reload: () => void
+}
+
+const props = defineProps<Props>()
+
+const api = useApi()
+
+const logMessage = ref('')
+
+const localStorageKey = computed(() => `rpc:saved-approval-log-${props.draftName}`)
+
+onMounted(() => {
+  const val = localStorageWrapper.getItem(localStorageKey.value)
+  if (typeof val === 'string') {
+    logMessage.value = `${
+      logMessage.value // preserve any value typed before restoring value
+    }${val}`
+  }
+})
+
+watch(logMessage, () => {
+  localStorageWrapper.setItem(localStorageKey.value, logMessage.value)
+})
+
+const isSubmitting = ref(false)
+
+const snackbar = useSnackbar()
+
+const handleSubmit = async () => {
+  try {
+    isSubmitting.value = true
+    await api.documentsApprovalLogsCreate({
+      draftName: props.draftName,
+      approvalLogMessageRequest: {
+        logMessage: logMessage.value
+      }
+    })
+    // assume approval log was successfully created so clean up local state
+    isSubmitting.value = false
+    clearLocalStorage()
+    logMessage.value = ''
+    props.reload()
+  } catch (error: unknown) {
+    isSubmitting.value = false
+    // server can respond with validation errors that we should show users
+    snackbarForErrors({ snackbar, defaultTitle: 'Adding approval log message failed', error })
+  }
+}
+
+const clearLocalStorage = () =>
+  localStorageWrapper.removeItem(localStorageKey.value)
+</script>

--- a/client/app/components/RpcCommentTextarea.vue
+++ b/client/app/components/RpcCommentTextarea.vue
@@ -41,7 +41,7 @@
               size="1.1em"
               class="animate-spin mr-1"
             />
-            Post
+            Add comment (private)
           </button>
         </div>
       </form>

--- a/client/app/composables/useCommentsForDraft.ts
+++ b/client/app/composables/useCommentsForDraft.ts
@@ -3,6 +3,6 @@ export function useCommentsForDraft(draftName: string) {
   return useAsyncData(
     `comments-${draftName}`,
     () => api.documentsCommentsList({ draftName: draftName }),
-    { server: false }
+    { server: false, lazy: true }
   )
 }

--- a/client/app/pages/docs/[id]/enqueue.vue
+++ b/client/app/pages/docs/[id]/enqueue.vue
@@ -37,7 +37,7 @@
           <CardHeader title="Comments" />
         </template>
         <div v-if="rfcToBe && rfcToBe.id" class="flex flex-col items-center space-y-4">
-          <RpcTextarea v-if="rfcToBe" :draft-name="id" :reload-comments="commentsReload" class="w-4/5 min-w-100" />
+          <RpcCommentTextarea v-if="rfcToBe" :draft-name="id" :reload-comments="commentsReload" class="w-4/5 min-w-100" />
           <DocumentComments :draft-name="id" :rfc-to-be-id="rfcToBe.id" :is-loading="commentsPending"
             :error="commentsError" :comment-list="commentList" :reload-comments="commentsReload"
             class="w-3/5 min-w-100" />

--- a/client/app/pages/docs/[id]/index.vue
+++ b/client/app/pages/docs/[id]/index.vue
@@ -179,7 +179,7 @@
             <CardHeader title="Comments (private)" />
           </template>
           <div v-if="rfcToBe && rfcToBe.id" class="flex flex-col items-center space-y-4">
-            <RpcTextarea v-if="rfcToBe" :draft-name="draftName" :reload-comments="commentsReload"
+            <RpcCommentTextarea v-if="rfcToBe" :draft-name="draftName" :reload-comments="commentsReload"
               class="w-4/5 min-w-100" />
             <DocumentComments :draft-name="draftName" :rfc-to-be-id="rfcToBe.id" :is-loading="commentsPending"
               :error="commentsError" :comment-list="commentList" :reload-comments="commentsReload"
@@ -192,10 +192,10 @@
             <CardHeader title="Approval Logs (public)" />
           </template>
           <div v-if="rfcToBe && rfcToBe.id" class="flex flex-col items-center space-y-4">
-            <RpcTextarea v-if="rfcToBe" :draft-name="draftName" :reload-comments="approvalLogsListReload"
+            <RpcApprovalLogTextarea v-if="rfcToBe" :draft-name="draftName" :reload="approvalLogsListReload"
               class="w-4/5 min-w-100" />
             <DocumentApprovalLogs :draft-name="draftName" :rfc-to-be-id="rfcToBe.id" :is-loading="approvalLogsListPending"
-              :error="approvalLogsListError" :comment-list="approvalLogsList" :reload-comments="approvalLogsListReload"
+              :error="approvalLogsListError" :comment-list="approvalLogsList" :reload="approvalLogsListReload"
               class="w-3/5 min-w-100" />
           </div>
         </BaseCard>
@@ -235,9 +235,9 @@ const {
   error: approvalLogsListError,
   refresh: approvalLogsListReload
 } = await useAsyncData(
-    `comments-${draftName}`,
+    `approval-log-${draftName.value}`,
     () => api.documentsApprovalLogsList({ draftName: draftName.value }),
-    { server: false }
+    { server: false, lazy: true }
   )
 
 const {
@@ -265,7 +265,7 @@ const appliedLabels = computed(() => labels.value.filter((lbl) => {
 // todo retrieve assignments for a single draft more efficiently
 const { data: assignments, refresh: refreshAssignments } = await useAsyncData(
   () => api.assignmentsList(),
-  { server: false, default: () => [] as Assignment[] }
+  { server: false, lazy: true, default: () => [] as Assignment[] }
 )
 
 const rfcToBeAssignments = computed(() =>
@@ -345,7 +345,7 @@ watch(
 
 const { data: people } = await useAsyncData(
   () => api.rpcPersonList(),
-  { server: false, default: () => [] }
+  { server: false, lazy: true, default: () => [] }
 )
 
 const { data: relatedDocuments } = await useReferencesForDraft(draftName.value)
@@ -485,7 +485,5 @@ const openEmailModal = async () => {
       throw e
     }
   })
-
 }
-
 </script>

--- a/client/app/pages/docs/import.vue
+++ b/client/app/pages/docs/import.vue
@@ -114,7 +114,7 @@
           <div v-if="!backendPending" class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
             <div class="sm:col-span-4 space-y-4">
             <label for="comments" class="block text-sm font-medium leading-6 text-gray-900">Comments</label>
-            <RpcTextarea v-if="submission?.name"
+            <RpcCommentTextarea v-if="submission?.name"
               :draft-name="submission?.name"
               :reload-comments="comments.reload"
               class="w-4/5 min-w-100"


### PR DESCRIPTION
## feat

* approval logs, based off the components for comments. I've forked the comment components rather than abstracting/generalising them to keep it simpler, allow them to deviate in the future etc. If in the future we want to  consolidate the components we can.
* for comments (private) and approval logs (public) I've added 'private' and 'public' suffixes to headings and buttons to make it very clear to users. See screenshot

*screenshot*
<img width="648" height="618" alt="Screenshot_2025-11-27_11-03-55" src="https://github.com/user-attachments/assets/2e7573b7-f3f7-47bd-99b3-3995cbaa659a" />
