### PR TITLE
fix: Add success message after data truncation

### DIFF
--- a/rpc/management/commands/purge.py
+++ b/rpc/management/commands/purge.py
@@ -56,3 +56,5 @@ class Command(BaseCommand):
             Document.objects.all().delete()
             Label.objects.all().delete()
             Cluster.objects.all().delete()
+
+        self.stdout.write(self.style.SUCCESS("Data truncated successfully!"))


### PR DESCRIPTION
Add a success message similar to `errata_purge`.