### PR TITLE
chore: revert to python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
     - uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
 
     - name: Install dependencies
       working-directory: ./purple

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14
+FROM python:3.13
 LABEL maintainer="IETF Tools Team <tools-discuss@ietf.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The app base image was bumped to Python 3.14 by dependabot and this was not reviewed carefully enough. It was also never active because we did not rebuild the purple-app-base image.

We seem to have a dependency on pydantic V1, probably through django-rest-framework, and pydantic V1 is incompatible with Python 3.14. Enabling tests using Python 3.14 revealed the warning about this.

```
/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/pydantic/__init__.py:137: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
 ```

Dropping back to Python 3.13, which functionally amounts to upgrading from 3.12 to 3.13, notwithstanding that the files previously said 3.14.