### PR TITLE
chore(deps): bump openjdk to 25

### DIFF
--- a/docker/scripts/app-setup.sh
+++ b/docker/scripts/app-setup.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Install sudo
 apt-get update
-apt-get -y install --no-install-recommends nginx openjdk-17-jre tmux sudo 2>&1
+apt-get -y install --no-install-recommends nginx openjdk-25-jre tmux sudo 2>&1
 apt-get autoremove -y
 
 # Create or update a non-root user to match UID/GID.


### PR DESCRIPTION
openjdk-17 is not available in the new base image (ubuntu trixie)