### PR TITLE
feat: publish modal complexities

### DIFF
--- a/client/app/components/PublishModal.vue
+++ b/client/app/components/PublishModal.vue
@@ -20,13 +20,14 @@
       <div>
         <BaseCard>
           <template #header>
-            <CardHeader title="Complexity Indicators (mocked)" />
+            <CardHeader :title="`Complexity Indicators (${complexityItems.length})`" />
           </template>
           <ul class="list-disc flex flex-col gap-1 ml-4">
             <li v-for="complexityItem in complexityItems" class="pl-1 text-sm">
-              {{ complexityItem.label }}
+              <RpcLabel :label="complexityItem" />
             </li>
           </ul>
+          <p v-if="complexityItems.length === 0" class="italic">(none)</p>
         </BaseCard>
 
         <BaseCard>
@@ -74,10 +75,11 @@
 <script setup lang="ts">
 import { BaseButton } from '#components'
 import { overlayModalKey } from '~/providers/providerKeys';
-import type { RfcToBe } from '~/purple_client';
+import type { Label, RfcToBe } from '~/purple_client';
 
 type Props = {
   rfcToBe: RfcToBe
+  labels: Label[]
   onSuccess: () => void
 }
 
@@ -89,12 +91,15 @@ if (!overlayModalKeyInjection) {
   throw Error('Expected injection of overlayModalKey')
 }
 
-const complexityItems = computed(() => [
-  { label: 'XML code components' },
-  { label: 'IANA Considerations - Large' },
-  { label: 'Converted to V3' },
-  { label: 'Expedited' },
-])
+const complexityItems = computed(() => {
+  return props.labels.filter(label => {
+    const { id } = label
+    if (typeof id !== 'number') {
+      throw Error('Expected label id to be a number')
+    }
+    return props.rfcToBe.labels.includes(id) && label.isComplexity
+  })
+})
 
 const finalChecksItems = computed(() => [
   { isChecked: false, label: "Version control", id: 'version-controls' },

--- a/client/app/pages/docs/[id]/index.vue
+++ b/client/app/pages/docs/[id]/index.vue
@@ -104,11 +104,7 @@
         </BaseCard>
 
         <!-- Document Info -->
-        <DocInfoCard
-          :rfc-to-be="rawRfcToBe"
-          :draft-name="draftName"
-          @refresh="historyRefresh()"
-        />
+        <DocInfoCard :rfc-to-be="rawRfcToBe" :draft-name="draftName" @refresh="historyRefresh()" />
 
         <EditAuthors v-if="rfcToBe" :draft-name="draftName" v-model="rfcToBe" />
 
@@ -204,9 +200,9 @@
           <div v-if="rfcToBe && rfcToBe.id" class="flex flex-col items-center space-y-4">
             <RpcApprovalLogTextarea v-if="rfcToBe" :draft-name="draftName" :reload="approvalLogsListReload"
               class="w-4/5 min-w-100" />
-            <DocumentApprovalLogs :draft-name="draftName" :rfc-to-be-id="rfcToBe.id" :is-loading="approvalLogsListPending"
-              :error="approvalLogsListError" :comment-list="approvalLogsList" :reload="approvalLogsListReload"
-              class="w-3/5 min-w-100" />
+            <DocumentApprovalLogs :draft-name="draftName" :rfc-to-be-id="rfcToBe.id"
+              :is-loading="approvalLogsListPending" :error="approvalLogsListError" :comment-list="approvalLogsList"
+              :reload="approvalLogsListReload" class="w-3/5 min-w-100" />
           </div>
         </BaseCard>
       </div>
@@ -246,10 +242,10 @@ const {
   error: approvalLogsListError,
   refresh: approvalLogsListReload
 } = await useAsyncData(
-    `approval-log-${draftName.value}`,
-    () => api.documentsApprovalLogsList({ draftName: draftName.value }),
-    { server: false, lazy: true }
-  )
+  `approval-log-${draftName.value}`,
+  () => api.documentsApprovalLogsList({ draftName: draftName.value }),
+  { server: false, lazy: true }
+)
 
 const {
   data: history,
@@ -303,7 +299,7 @@ const rfcToBe = computed((): CookedDraft | null => {
 
 // DATA
 
-const { data: labels } = await useLabels()
+const { data: labels, status: labelsStatus } = await useLabels()
 
 const labels1 = computed(() =>
   labels.value.filter((label) => label.used && label.isComplexity && !label.isException)
@@ -502,6 +498,10 @@ const openPublishModal = () => {
   if (!overlayModal) {
     throw Error(`Expected modal provider ${JSON.stringify({ overlayModalKey })}`)
   }
+  if (labelsStatus.value !== 'success') {
+    snackbar.add({ type: "warning", title: "Still loading labels", text: "Try again soon" })
+    return
+  }
 
   const { openOverlayModal } = overlayModal
 
@@ -509,6 +509,7 @@ const openPublishModal = () => {
     component: PublishModal,
     componentProps: {
       rfcToBe: rfcToBe.value,
+      labels: labels.value,
       onSuccess: () => {
         historyRefresh()
       }


### PR DESCRIPTION
## feat

* the publish modal had a mocked list of complexities, but now it's based on the `rfcToBe` and the API of labels with the `isComplexity` flag