### PR TITLE
feat: publish modal use API publish

### DIFF
--- a/client/app/components/PublishModal.vue
+++ b/client/app/components/PublishModal.vue
@@ -67,7 +67,7 @@
     </div>
     <div class="border-t-1 border-gray-800 flex justify-end items-center">
       <BaseButton btnType="default" class="m-2 flex items-center" @click="handlePublish">
-        Publish (mocked)
+        Publish
       </BaseButton>
     </div>
   </div>
@@ -122,10 +122,32 @@ const clearedExceptionsItems = computed(() => [
   { isChecked: false, label: "Conversion to V3 XML failed", id: 'conversion-to-v3-xml-failed' },
 ])
 
+const snackbar = useSnackbar()
+
+const api = useApi()
+
 const { closeOverlayModal } = overlayModalKeyInjection
 
-const handlePublish = () => {
-  alert("this doesn't work yet")
-  closeOverlayModal()
+const handlePublish = async () => {
+  const { name } = props.rfcToBe
+
+  if (name === undefined) {
+    snackbar.add({
+      type: "error",
+      title: "Can't publish without draft name",
+      text: "(internal error)"
+    })
+    return
+  }
+  try {
+    await api.documentsPublish({
+      draftName: name
+    })
+
+    props.onSuccess()
+    closeOverlayModal()
+  } catch (error) {
+    snackbarForErrors({ snackbar, error, defaultTitle: "Couldn't publish" })
+  }
 }
 </script>


### PR DESCRIPTION
## feat

* publish modal: use API for publishing


*screenshots*

*the button*
<img width="169" height="104" alt="Screenshot_2025-12-02_10-13-26" src="https://github.com/user-attachments/assets/85b10dce-ee09-4a07-a959-348c66bdb69b" />

*handles server errors if there are any*
<img width="509" height="138" alt="Screenshot_2025-12-02_10-13-28" src="https://github.com/user-attachments/assets/8f5687d4-fadd-4ed6-a6c6-4b458d603cbe" />
