### PR TITLE
feat: final reviews columns (cluster, assignmentSet)

### DIFF
--- a/client/app/components/FinalReviews.vue
+++ b/client/app/components/FinalReviews.vue
@@ -1,15 +1,15 @@
 <template>
-  <FinalReviewsInProgress :name="props.name" :heading-level="4" />
+  <FinalReviewsInProgress :name="props.name" :heading-level="4" :people="people" />
   <ErrorAlert v-if="error" title="API Error for Done / PUB">
     {{ error }}
   </ErrorAlert>
-  <FinalReviewsDone :queue-items="queueItemsFilterDone" :error="error" :status="status" :heading-level="4" />
-  <FinalReviewsForPublication :queue-items="queueItemsFilterPublisher" :error="error" :status="status"
+  <FinalReviewsDone :queue-items="queueItemsFilterDone" :error="error" :status="status" :heading-level="4" :people="people" />
+  <FinalReviewsForPublication :queue-items="queueItemsFilterPublisher" :error="error" :status="status" :people="people"
     :heading-level="4" />
 </template>
 
 <script setup lang="ts">
-import type { QueueItem } from '~/purple_client';
+import type { QueueItem, RpcPerson } from '~/purple_client';
 
 type Props = {
   name?: string
@@ -59,5 +59,11 @@ const queueItemsFilterDone = computed((): QueueItem[] => {
   return queueListWithFilters.value?.filter(
     queueItem => queueItemsFilterPublisher.value.every(queueItemPublisher => queueItemPublisher.id !== queueItem.id)
   ) ?? []
+})
+
+const { data: people, status: peopleStatus, error: peopleError } = await useAsyncData(() => api.rpcPersonList(), {
+  server: false,
+  lazy: true,
+  default: () => [] as RpcPerson[]
 })
 </script>

--- a/client/app/components/FinalReviewsDone.vue
+++ b/client/app/components/FinalReviewsDone.vue
@@ -55,15 +55,17 @@ import {
   getSortedRowModel,
   type SortingState,
 } from '@tanstack/vue-table'
-import type { QueueItem } from '~/purple_client'
+import type { QueueItem, RpcPerson } from '~/purple_client'
 import { ANCHOR_STYLE } from '~/utils/html'
 import type { HeadingLevel } from '~/utils/html'
+import { columnFormatterCluster } from '~/utils/finalreviews'
 
 type Props = {
   queueItems: QueueItem[]
   error?: NuxtError<unknown>
   status: AsyncDataRequestStatus
   headingLevel?: HeadingLevel
+  people: RpcPerson[]
 }
 
 const props = withDefaults(defineProps<Props>(), { headingLevel: 2 })
@@ -96,7 +98,33 @@ const columns = [
     header: 'Pages',
     cell: data => data.getValue(),
     sortingFn: 'alphanumeric',
-  })
+  }),
+  columnHelper.accessor(
+    'cluster', {
+    header: 'Cluster',
+    cell: data => {
+      const clusterNumber = data.getValue()?.number
+      return columnFormatterCluster(clusterNumber)
+    },
+    sortingFn: 'alphanumeric',
+  }),
+  columnHelper.accessor(
+    'assignmentSet',
+    {
+      header: 'Assignees',
+      cell: (data) => {
+        const assignments = data.getValue()
+        return columnFormatterAssignments({
+          assignments,
+          rfcToBeId: data.row.original.id,
+          people: props.people,
+          queueItemsIsPending: props.status === 'pending',
+          rowForDebug: data.row.original
+        })
+      },
+      enableSorting: false,
+    }
+  ),
 ]
 
 const sorting = ref<SortingState>([])

--- a/client/app/components/FinalReviewsForPublication.vue
+++ b/client/app/components/FinalReviewsForPublication.vue
@@ -54,7 +54,7 @@ import {
   getSortedRowModel,
   type SortingState,
 } from '@tanstack/vue-table'
-import type { QueueItem } from '~/purple_client'
+import type { QueueItem, RpcPerson } from '~/purple_client'
 import { ANCHOR_STYLE } from '~/utils/html'
 import type { HeadingLevel } from '~/utils/html'
 
@@ -63,6 +63,7 @@ type Props = {
   error?: NuxtError<unknown>
   status: AsyncDataRequestStatus
   headingLevel?: HeadingLevel
+  people: RpcPerson[]
 }
 
 const props = withDefaults(defineProps<Props>(), { headingLevel: 2 })
@@ -95,7 +96,33 @@ const columns = [
     header: 'Pages',
     cell: data => data.getValue(),
     sortingFn: 'alphanumeric',
-  })
+  }),
+  columnHelper.accessor(
+    'cluster', {
+    header: 'Cluster',
+    cell: data => {
+      const clusterNumber = data.getValue()?.number
+      return columnFormatterCluster(clusterNumber)
+    },
+    sortingFn: 'alphanumeric',
+  }),
+  columnHelper.accessor(
+    'assignmentSet',
+    {
+      header: 'Assignees',
+      cell: (data) => {
+        const assignments = data.getValue()
+        return columnFormatterAssignments({
+          assignments,
+          rfcToBeId: data.row.original.id,
+          people: props.people,
+          queueItemsIsPending: props.status === 'pending',
+          rowForDebug: data.row.original
+        })
+      },
+      enableSorting: false,
+    }
+  ),
 ]
 
 const sorting = ref<SortingState>([])

--- a/client/app/utils/finalreviews.ts
+++ b/client/app/utils/finalreviews.ts
@@ -1,0 +1,96 @@
+import { Anchor, Icon, BaseBadge } from '#components'
+import { groupBy } from 'lodash-es'
+import type { Assignment, Cluster, RpcPerson } from '~/purple_client'
+
+export const columnFormatterCluster = (clusterNumber?: Cluster["number"]) => {
+  if (!clusterNumber) {
+    return '-'
+  }
+  return h('span', [
+    h(Anchor, {
+      href: `/clusters/${clusterNumber}`,
+      class: "inline-flex items-center gap-1 text-blue-600"
+    }, () => [
+      h(Icon, { name: "pajamas:group", class: "h-5 w-5" }),
+      clusterNumber
+    ])
+  ])
+}
+
+type ColumnFormatterAssignmentsProps = {
+  assignments?: Assignment[],
+  rfcToBeId?: number,
+  people: RpcPerson[],
+  queueItemsIsPending: boolean,
+  rowForDebug: unknown,
+}
+
+export const columnFormatterAssignments = ({ assignments, rfcToBeId, people, queueItemsIsPending, rowForDebug }: ColumnFormatterAssignmentsProps) => {
+  if (!assignments) {
+    return 'No assignments'
+  }
+
+  if (rfcToBeId === undefined) {
+    throw Error(`Internal error: expected queueItem to have id but was ${JSON.stringify(rowForDebug)}`)
+  }
+
+  const listItems: VNode[] = []
+
+  const assignmentsByRoles = groupBy(
+    assignments,
+    (assignment) => assignment.role
+  )
+
+  const orderedRoles = Object.keys(assignmentsByRoles)
+    .sort((a, b) => a.localeCompare(b, 'en'))
+
+  for (const role of orderedRoles) {
+    const assignmentsOfRole = assignmentsByRoles[role] ?? []
+
+    const redundantAssignmentsOfSamePersonToSameRole = assignmentsOfRole.filter((assignment, _index, arr) => {
+      const { person } = assignment
+      if (person === undefined || person == null) {
+        return false
+      }
+      const firstAssignmentOfPersonToRole = arr.find(arrAssignment => assignment.person && arrAssignment.person && arrAssignment.person === assignment.person)
+      if (!firstAssignmentOfPersonToRole) {
+        console.log(`Couldn't find first assignment for person #${assignment.person} in`, arr)
+        throw Error(`Internal error. Should be able to find first assignment for person #${assignment.person}. See console`)
+      }
+      // the first assignment of person in the list of assignments should always match the current assignment of person
+      // because there shouldn't be duplicate/redundant assignments
+      // but if the id is different then it is a redundant assignment,
+      // so we'll prompt the user to delete them
+      return assignment.id !== firstAssignmentOfPersonToRole.id
+    })
+
+    listItems.push(h('li', { class: 'flex gap-3' }, [
+      h('span',
+        h(BaseBadge, { label: role, class: 'mr-1' })),
+      h('ul', { class: 'flex flex-col gap-2' }, [
+        ...assignmentsOfRole.map(assignment => {
+          const rpcPerson = people.find((p) => p.id === assignment.person)
+          return h(Anchor, {
+            href: rpcPerson ? `/team/${rpcPerson.id}` : undefined,
+            class: [ANCHOR_STYLE, 'text-sm nowrap']
+          }, () => [
+            rpcPerson ? rpcPerson.name : queueItemsIsPending ? `...` : '(unknown person)',
+          ])
+        }).reduce((acc, item, index, arr) => {
+          // add commas between items
+          const listItemChildren = []
+          listItemChildren.push(item)
+          if (index < arr.length - 1) {
+            listItemChildren.push(', ')
+          } else {
+            listItemChildren.push(' ')
+          }
+          const listItem = h('li', listItemChildren)
+          acc.push(listItem)
+          return acc
+        }, [] as (VNode | string)[])]),
+    ]))
+  }
+
+  return h('ul', { class: 'flex flex-col gap-x-1 gap-y-3' }, listItems)
+}


### PR DESCRIPTION
## feat

* The final reviews page has 3 tables, and this makes table 1's columns for cluster and assignmentSet also appear on tables 2 and 3. fixes #622 

*screenshot*
<img width="464" height="491" alt="Screenshot_2025-12-02_11-06-07" src="https://github.com/user-attachments/assets/1cd3ef96-b16c-4b3c-910c-6a474589308c" />
