### PR TITLE
fix: auth wall

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!ifAuthRoute && userStore.authenticated === undefined" class="w-[3.5em] mt-2 mx-auto">
+  <div v-if="userStore.authenticated !== true" class="w-[3.5em] mt-2 mx-auto">
     <Icon
       name="ei:spinner-3"
       size="3.5em"


### PR DESCRIPTION
## fix

* simplifies logic around auth wall. There was faulty logic after authentication was received but before the browser has unloaded the page and redirected to the auth.
* adds `console.log`ging to auth wall logic. turn on 'preserve logs' to log through the redirects.
* adds logic about unhandled auth responses which cause the page to reload after 10 seconds. This is just trying to recover from unexpected network responses during the initial fetch of `/api/rpc/profile/` (eg transient network failures, server JSON schema changing) by trying to load again.

resolves #643