### PR TITLE
chore: auth wall tidy up

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -1,18 +1,5 @@
 <template>
-  <div v-if="userStore.authenticated !== true" class="w-[3.5em] mt-2 mx-auto">
-    <Icon
-      name="ei:spinner-3"
-      size="3.5em"
-      class="animate-spin"
-    />
-  </div>
-  <NuxtLayout v-else>
+  <NuxtLayout>
     <NuxtPage />
   </NuxtLayout>
 </template>
-
-<script setup lang="ts">
-import { useUserStore } from '@/stores/user'
-
-const userStore = useUserStore()
-</script>

--- a/client/app/components/AuthWallSpinner.vue
+++ b/client/app/components/AuthWallSpinner.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="w-[3.5em] mt-2 mx-auto">
+    <Icon name="ei:spinner-3" size="3.5em" class="animate-spin" />
+  </div>
+</template>

--- a/client/app/components/DefaultLayoutAfterAuthWall.vue
+++ b/client/app/components/DefaultLayoutAfterAuthWall.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    <SidebarNav />
+    <main class="lg:pl-72">
+      <HeaderNav />
+      <div class="px-4 py-10 sm:px-6 lg:px-8 lg:py-6">
+        <slot  />
+      </div>
+    </main>
+    <OverlayModal
+      v-model:is-shown="overlayModalState.isShown"
+      :opts="overlayModalState.opts"
+      @close-ok="overlayModalState.promiseResolve"
+      @close-cancel="overlayModalState.promiseReject"
+    />
+    <NuxtSnackbar />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useDefaultHead } from '~/utils/head'
+import { overlayModalKey } from '../providers/providerKeys'
+import type { OverlayModal } from '../providers/providerKeys'
+
+useDefaultHead()
+
+onMounted(() => onMountedScrollToHash())
+
+// OVERLAY MODAL
+
+type OverlayModalState = {
+  isShown: boolean
+  opts: Parameters<OverlayModal['openOverlayModal']>[0]
+  promiseResolve?: (value?: string | PromiseLike<string | undefined>) => void
+  promiseReject?: (reason?: any) => void
+}
+
+const overlayModalState = shallowReactive<OverlayModalState>({
+  isShown: false,
+  opts: {
+    component: undefined,
+    componentProps: undefined
+  },
+  promiseResolve: undefined,
+  promiseReject: undefined
+})
+
+provide(overlayModalKey, {
+  openOverlayModal: (opts) => {
+    overlayModalState.opts = {
+      component: opts.component,
+      componentProps: opts.componentProps ?? {},
+      mode: opts.mode ?? 'overlay'
+    }
+    return new Promise<string | undefined>((resolve, reject) => {
+      overlayModalState.promiseResolve = resolve
+      overlayModalState.promiseReject = reject
+      overlayModalState.isShown = true
+    })
+  },
+  /**
+   * Close the active overlay modal
+   */
+  closeOverlayModal: () => {
+    if (overlayModalState.promiseReject) {
+      overlayModalState.isShown = false
+      overlayModalState.promiseReject()
+    }
+  }
+})
+</script>
+
+<style>
+:root { font-family: 'Inter', sans-serif; }
+@supports (font-variation-settings: normal) {
+  :root { font-family: 'Inter var', sans-serif; }
+}
+
+body {
+  background-color: #f9fafb;
+}
+.dark body {
+  background-color: #0a0a0a;
+}
+#__nuxt {
+  min-height: 100vh
+}
+</style>

--- a/client/app/layouts/default.vue
+++ b/client/app/layouts/default.vue
@@ -1,98 +1,11 @@
 <template>
-  <div v-if="userStore.authenticated !== true" class="w-[3.5em] mt-2 mx-auto">
-    <Icon
-      name="ei:spinner-3"
-      size="3.5em"
-      class="animate-spin"
-    />
-  </div>
-  <div v-else>
-    <SidebarNav />
-    <main class="lg:pl-72">
-      <HeaderNav />
-      <div class="px-4 py-10 sm:px-6 lg:px-8 lg:py-6">
-        <slot  />
-      </div>
-    </main>
-    <OverlayModal
-      v-model:is-shown="overlayModalState.isShown"
-      :opts="overlayModalState.opts"
-      @close-ok="overlayModalState.promiseResolve"
-      @close-cancel="overlayModalState.promiseReject"
-    />
-    <NuxtSnackbar />
-  </div>
+  <AuthWallSpinner v-if="userStore.authenticated !== true" />
+  <DefaultLayoutAfterAuthWall v-else>
+    <slot  />
+  </DefaultLayoutAfterAuthWall>
 </template>
 
 <script setup lang="ts">
 import { useUserStore } from '@/stores/user'
-import { useDefaultHead } from '~/utils/head'
-import { overlayModalKey } from '../providers/providerKeys'
-import type { OverlayModal } from '../providers/providerKeys'
-
 const userStore = useUserStore()
-
-useDefaultHead()
-
-onMounted(() => onMountedScrollToHash())
-
-// OVERLAY MODAL
-
-type OverlayModalState = {
-  isShown: boolean
-  opts: Parameters<OverlayModal['openOverlayModal']>[0]
-  promiseResolve?: (value?: string | PromiseLike<string | undefined>) => void
-  promiseReject?: (reason?: any) => void
-}
-
-const overlayModalState = shallowReactive<OverlayModalState>({
-  isShown: false,
-  opts: {
-    component: undefined,
-    componentProps: undefined
-  },
-  promiseResolve: undefined,
-  promiseReject: undefined
-})
-
-provide(overlayModalKey, {
-  openOverlayModal: (opts) => {
-    overlayModalState.opts = {
-      component: opts.component,
-      componentProps: opts.componentProps ?? {},
-      mode: opts.mode ?? 'overlay'
-    }
-    return new Promise<string | undefined>((resolve, reject) => {
-      overlayModalState.promiseResolve = resolve
-      overlayModalState.promiseReject = reject
-      overlayModalState.isShown = true
-    })
-  },
-  /**
-   * Close the active overlay modal
-   */
-  closeOverlayModal: () => {
-    if (overlayModalState.promiseReject) {
-      overlayModalState.isShown = false
-      overlayModalState.promiseReject()
-    }
-  }
-})
 </script>
-
-<style>
-:root { font-family: 'Inter', sans-serif; }
-@supports (font-variation-settings: normal) {
-  :root { font-family: 'Inter var', sans-serif; }
-}
-
-body {
-  background-color: #f9fafb;
-}
-.dark body {
-  background-color: #0a0a0a;
-}
-#__nuxt {
-  min-height: 100vh
-}
-</style>

--- a/client/app/pages/auth.vue
+++ b/client/app/pages/auth.vue
@@ -13,8 +13,6 @@
 </template>
 
 <script setup lang="ts">
-import { useDefaultHead } from '~/utils/head'
-
 const route = useRoute()
 
 // mozilla_django_oidc supports a url param `next` to return to the current path https://mozilla-django-oidc.readthedocs.io/en/stable/settings.html?highlight=next#OIDC_REDIRECT_FIELD_NAME
@@ -23,10 +21,11 @@ const nextParam = computed(() => {
   return typeof next === 'string' ? `?next=${encodeURIComponent(next)}` : ''
 })
 
-useDefaultHead()
-
 definePageMeta({
   layout: false,
 })
 
+useHead({
+  title: 'Login'
+})
 </script>


### PR DESCRIPTION
## chore / fix

* In #679 another layer of auth wall was added to `layouts/default.vue` which fixed the problem, so now we don't need the top level `app.vue` auth wall which caused the Nuxt warning #312 and it's been removed.
* the new auth wall was added to `layouts/default.vue` and that component had imports/scripts already that weren't conditionally run after authentication. Those scripts could have called an API. It would be better to ensure we conditionally run those scripts by moving all that to a lower component, hence `DefaultLayoutAfterAuthWall.vue`.