### PR TITLE
feat: add validator for unusable RFC numbers

### DIFF
--- a/rpc/models.py
+++ b/rpc/models.py
@@ -5,9 +5,9 @@ import logging
 from dataclasses import dataclass
 from itertools import pairwise
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import OuterRef, Prefetch, Subquery
-from django.core.exceptions import ValidationError
 from django.utils import timezone
 from rules import always_deny
 from rules.contrib.models import RulesModel


### PR DESCRIPTION
add validator to test that the RFC number is not in unusable Numbers list.

needed to move UnusableRfcNumber up in code

fixes #685 