### PR TITLE
fix: cluster diagram

### DIFF
--- a/client/app/components/RpcCheckbox.vue
+++ b/client/app/components/RpcCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['relative flex items-start', props.class]">
+  <div :class="['relative flex items-start cursor-pointer', props.class]">
     <div class="flex h-6 items-center">
       <input
         v-bind="$attrs"
@@ -8,17 +8,17 @@
         :aria-describedby="desc ? descriptionId : undefined"
         type="checkbox"
         :checked="props.checked"
-        :class="[caution ? 'border-rose-300 dark:border-rose-500 text-rose-700 dark:text-rose-700 hover:border-rose-400 focus:ring-rose-600' : 'border-gray-300 dark:border-neutral-500 text-violet-600 dark:text-violet-500 hover:border-violet-400 dark:hover:border-violet-500 focus:ring-violet-600 dark:focus:ring-violet-500', 'h-4 w-4 bg-white dark:bg-neutral-900 rounded border-2']"
+        :class="[caution ? 'border-rose-300 dark:border-rose-500 text-rose-700 dark:text-rose-700 hover:border-rose-400 focus:ring-rose-600' : 'border-gray-300 dark:border-neutral-500 text-violet-600 dark:text-violet-500 hover:border-violet-400 dark:hover:border-violet-500 focus:ring-violet-600 dark:focus:ring-violet-500', 'h-4 w-4 bg-white dark:bg-neutral-900 rounded border-2 cursor-pointer']"
       >
     </div>
     <div :class="{
-      'ml-3 leading-6': true,
+      'ml-3 leading-6 cursor-pointer': true,
       'text-sm': props.size === 'medium',
       'text-xs': props.size === 'small',
     }">
       <label
         :for="inputId"
-        :class="[caution ? 'text-rose-800 dark:text-rose-400' : 'text-gray-900 dark:text-neutral-200', 'font-medium']">
+        :class="[caution ? 'text-rose-800 dark:text-rose-400' : 'text-gray-900 dark:text-neutral-200', 'font-medium cursor-pointer']">
         {{ label }}
       </label>
       <p

--- a/client/app/utils/document_relations-utils.ts
+++ b/client/app/utils/document_relations-utils.ts
@@ -1,11 +1,9 @@
-import { uniqBy } from "lodash-es";
-
 /**
  * These constants were calculated from DOM Bootstrap CSS variables
  * so they've been hardcoded to ensure same rendering
  * If you change them please test a lot.
  */
-export const font_size = 16;
+export const font_size = 14;
 export const line_height = font_size + 2;
 export const font_family =
   '"Inter",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue","Noto Sans","Liberation Sans",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"';
@@ -67,6 +65,7 @@ export const parseLevel = (maybeLevel: string): Level => {
 export type Line = {
   text: string;
   width: number;
+  style?: string
 };
 
 export type Node = NodeParam & {

--- a/client/app/utils/document_relations.ts
+++ b/client/app/utils/document_relations.ts
@@ -53,15 +53,25 @@ function stroke(d: NodeParam) {
 // code partially adapted from
 // https://observablehq.com/@mbostock/fit-text-to-circle
 
-function lines(text: string): Line[] {
+
+type LinesProps= { id: string, rfcNumber?: number }
+function lines({ id, rfcNumber }: LinesProps): Line[] {
   let line_width_0 = Infinity
+  let text = id
   let line: Line = {
-    // TODO: setting a default value is a change when porting to TS. This might be wrong
     text,
     width: line_width_0,
   }
 
   const lines: Line[] = []
+  if(rfcNumber) {
+    const newRfcNumber = `RFC ${rfcNumber}`
+    lines.push({
+      text: newRfcNumber,
+      width: newRfcNumber.length * 10,
+      style: 'font-weight: bold'
+    })
+  }
   let sep = "-"
   let words = text.trim().split(/-/g)
   if (words.length == 1) {
@@ -220,13 +230,10 @@ export function draw_graph(data: DataParam, pushRouter: (path: string) => void) 
   a.append("text")
     .attr("fill", (d) => (d.isRfc || d.isReplaced ? white : black))
     .each((d) => {
-      (d as Node).lines = lines([
-          d.rfcNumber ? `RFC${d.rfcNumber}` : undefined,
-          d.id
-        ]
-        .filter(Boolean)
-        .join(",")
-      );
+      (d as Node).lines = lines({
+        rfcNumber: d.rfcNumber,
+        id: d.id,
+      });
       (d as Node).r = text_radius((d as Node).lines!)
       max_r = Math.max((d as Node).r, max_r)
     })
@@ -234,6 +241,7 @@ export function draw_graph(data: DataParam, pushRouter: (path: string) => void) 
     .data((d) => (d as Node).lines ?? [])
     .join("tspan")
     .attr("x", 0)
+    .attr("style", (d) => d.style ?? '')
     .attr("y", (d, i, x) => (i - x.length / 2 + 0.5) * line_height)
     .text((d) => d.text)
 


### PR DESCRIPTION
## fix

* cluster diagram RFC number boldness and general text layout fixes

## chore

* adding *'Diagram data (for debug)'* to help with cluster diagram development (see bottom-right of screenshot)
* adding CSS `cursor:pointer` to RPC checkbox

*screenshot* (note the RFC10k is on a local dev machine and not a real RFC number)
<img width="1679" height="618" alt="Screenshot_2025-12-05_11-03-06" src="https://github.com/user-attachments/assets/03949009-9402-46df-94bc-e34e83c52a04" />
