### PR TITLE
feat: cluster reorder fields

### DIFF
--- a/client/app/components/ClusterReorder.vue
+++ b/client/app/components/ClusterReorder.vue
@@ -1,18 +1,51 @@
 <template>
   <BaseCard>
     <template #header>
-      <CardHeader :title="`Reorder Cluster ${props.cluster.number}`" />
+      <CardHeader :title="`Reorder Cluster ${props.cluster.number}`">
+        <template #actions>
+          <Icon v-if="queueStatus === 'pending' || labelsStatus === 'pending'" name="ei:spinner-3" size="1.3rem" class="animate-spin" title="Loading additional information about cluster documents" />
+          <span v-else-if="queueStatus === 'error' || labelsStatus === 'error'" class="text-red-800 dark:text-red-400">
+            {{ queueError }}
+            {{ labelsError }}
+          </span>
+        </template>
+      </CardHeader>
     </template>
     <p class="italic text-sm">(drag to reorder)</p>
     <ol ref="parent" class="min-w-[200px] mb-6">
       <li v-for="(clusterDocument, index) in clusterDocumentsRef" :index="index" :key="clusterDocument.name"
         class="flex justify-between items-center pl-2 cursor-ns-resize pr-1 py-1 mt-1 bg-white dark:bg-gray-700 border rounded-md border-gray-400 select-none">
-        <span class="flex items-center">
+        <span class="flex items-center font-semibold text-sm w-[350px]">
           <Icon name="fluent:re-order-dots-vertical-24-regular" class="mr-2" />
           {{ clusterDocument.name }}
         </span>
 
-        <button type="button" class="p-2 rounded-md bg-gray-100 text-gray-800 hover:bg-gray-200 focus:bg-gray-200" :aria-label="`Remove ${clusterDocument.name}`" @click="() => removeDocument(clusterDocument.name)">&times</button>
+        <span class="w-[200px]">
+          <span v-if="rfcToBeLabelsByName[clusterDocument.name]"
+            v-for="(label, labelIndex) in rfcToBeLabelsByName[clusterDocument.name]" :key="labelIndex">
+            <RpcLabel :label="label" />
+          </span>
+          <span v-else-if="labelsStatus === 'pending'">
+            <!-- <Icon name="ei:spinner-3" size="1.3rem" class="animate-spin" /> -->
+          </span>
+          <span v-else-if="labelsStatus === 'success' && queueStatus === 'success'"
+            title="Couldn't find rfcToBe in queue">
+            ?
+          </span>
+        </span>
+
+        <span class="w-[100px]">
+          <span v-if="enqueuedAtByDraftName[clusterDocument.name]">
+            <component :is="enqueuedAtByDraftName[clusterDocument.name]" />
+          </span>
+          <span v-else-if="queueStatus === 'pending'">
+            <!-- <Icon name="ei:spinner-3" size="1.3rem" class="animate-spin" /> -->
+          </span>
+        </span>
+
+        <button type="button" class="p-2 rounded-md bg-gray-100 text-gray-800 hover:bg-gray-200 focus:bg-gray-200"
+          :aria-label="`Remove ${clusterDocument.name}`"
+          @click="() => removeDocument(clusterDocument.name)">&times</button>
       </li>
     </ol>
     <div class="flex mx-3 py-3 justify-end border-t border-gray-300">
@@ -23,19 +56,96 @@
 
 <script setup lang="ts">
 import { useDragAndDrop } from "fluid-dnd/vue";
-import type { Cluster } from '~/purple_client'
+import { type Cluster, type RfcToBe, type Label, type QueueItem } from '~/purple_client'
 import BaseButton from './BaseButton.vue'
+import { calculateEnqueuedAtData, renderEnqueuedAt } from '../utils/queue'
 
 type Props = {
   cluster: Cluster
   onSuccess: () => Promise<void>
+  rfcsToBe?: RfcToBe[]
 }
+
+const {
+  data: queue,
+  status: queueStatus,
+  pending,
+  refresh,
+  error: queueError,
+} = await useAsyncData(
+  'queue-for-cluster',
+  () => api.queueList(),
+  {
+    server: false,
+    lazy: true,
+    default: () => [] as QueueItem[],
+  }
+)
 
 const snackbar = useSnackbar()
 
 const props = defineProps<Props>()
 
+type QueueItemByDraftName = Record<string, QueueItem | undefined>
+
+const queueItemByDraftName = computed(() => queue.value.reduce((acc, queueItem) => {
+  const { name } = queueItem
+  if (name !== undefined) {
+    acc[name] = queueItem
+  }
+  return acc
+}, {} as QueueItemByDraftName))
+
+type EnqueuedAtByDraftName = Record<string, ReturnType<typeof renderEnqueuedAt> | undefined>
+const enqueuedAtByDraftName = computed(() => queue.value.reduce((acc, queueItem) => {
+  const { name, enqueuedAt, cluster } = queueItem
+  if (name !== undefined && enqueuedAt) {
+    const vNodes = renderEnqueuedAt(calculateEnqueuedAtData(enqueuedAt))
+    if (cluster?.number === props.cluster.number) {
+      console.log("cluster hit", name)
+    } else {
+      console.log("cluster miss", name)
+    }
+    acc[name] = vNodes
+  }
+  return acc
+}, {} as EnqueuedAtByDraftName))
+
 const clusterDocumentsRef = ref(props.cluster.documents ?? [])
+
+const { data: labels, status: labelsStatus, error: labelsError } = await useAsyncData(
+  `labels-lazy`,
+  () => api.labelsList(),
+  {
+    default: () => ([] as Label[]),
+    server: false,
+    lazy: true,
+  }
+)
+
+type LabelsById = Record<number, Label | undefined>
+
+const labelsById = computed(() => labels.value.reduce((acc, label) => {
+  const { id } = label
+  if (id) {
+    acc[id] = label
+  }
+  return acc
+}, {} as LabelsById))
+
+type RfcToBeLabelsByName = Record<string, Label[] | undefined>
+
+const rfcToBeLabelsByName = computed(() => props.rfcsToBe?.reduce((acc, rfcToBe) => {
+  const { name } = rfcToBe
+  if (!name) {
+    throw Error('Expected item to have id')
+  }
+  if (labels.value.length > 0) {
+    const rfcToBeLabelsResolved = rfcToBe.labels.map(labelId => labelsById.value[labelId]).filter(item => !!item)
+    acc[name] = rfcToBeLabelsResolved.length > 0 ? rfcToBeLabelsResolved : undefined
+  }
+  return acc
+}, {} as RfcToBeLabelsByName) ?? {})
 
 const [parent] = useDragAndDrop(clusterDocumentsRef);
 
@@ -43,7 +153,7 @@ const api = useApi()
 
 const removeDocument = async (name: string) => {
   const reallyRemove = confirm(`Really remove ${JSON.stringify(name)} from cluster?`)
-  if(!reallyRemove) {
+  if (!reallyRemove) {
     console.info("User rejected removing member from cluster")
     return
   }

--- a/client/app/components/DocumentDependenciesGraph.vue
+++ b/client/app/components/DocumentDependenciesGraph.vue
@@ -37,8 +37,8 @@
     </span>
   </div>
 
-  <details class="mt-10 float-right pb-10">
-    <summary class="font-bold cursor-pointer">Diagram data (for debug)</summary>
+  <details class="mt-10 pb-10">
+    <summary class="flex justify-end font-bold cursor-pointer">Diagram data (for debug)</summary>
 
     <div class="ml-4">
       <h3 class="mt-4 font-bold">Cluster</h3>
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { uniq, uniqBy } from 'lodash-es';
+import { uniqBy } from 'lodash-es';
 import { type Cluster, type RfcToBe } from '~/purple_client'
 import { drawGraph, type DrawGraphParameters, type SetTooltip } from '~/utils/document_relations';
 import { legendData, complexClusterExample, type DataParam, type LinkParam, type NodeParam } from '~/utils/document_relations-utils'
@@ -58,6 +58,7 @@ import { downloadTextFile } from '~/utils/download';
 
 type Props = {
   cluster: Cluster
+  rfcsToBe?: RfcToBe[]
 }
 
 const props = defineProps<Props>()
@@ -85,29 +86,6 @@ const snackbarMessage = (title: string, type: SnackbarType = 'error'): void => {
 }
 
 const api = useApi()
-
-const { data: rfcsToBe, refresh } = useAsyncData(`cluster-rfcs-${clusterToUse.value.number}`, async () => {
-  const names = clusterToUse.value.documents?.flatMap((document): string[] => {
-    return [document.name,
-    ...(document.references ?? []).flatMap(reference => {
-      return [reference.draftName, reference.targetDraftName].filter(val => typeof val === 'string')
-    })
-    ]
-  }) ?? []
-
-  const uniqueNames = uniq(names)
-
-  console.log({ uniqueNames })
-
-  const drafts = await Promise.all(uniqueNames.map((draftName) =>
-    api.documentsRetrieve({ draftName })
-  ))
-  console.log({ drafts })
-  return drafts
-}, {
-  server: false,
-  lazy: true,
-})
 
 
 const handleChange = (e: Event) => {
@@ -180,7 +158,7 @@ const clusterGraphData = computed(() => {
   }
 
   type RfcByDraftName = Record<string, RfcToBe>
-  const rfcsByDraftName: RfcByDraftName = rfcsToBe.value ? rfcsToBe.value.reduce((acc, rfcToBe) => {
+  const rfcsByDraftName: RfcByDraftName = props.rfcsToBe ? props.rfcsToBe.reduce((acc, rfcToBe) => {
     const { name } = rfcToBe
     if (name) {
       acc[name] = rfcToBe

--- a/client/app/pages/queue/queue.vue
+++ b/client/app/pages/queue/queue.vue
@@ -123,8 +123,8 @@ import {
 import type { SortingState } from '@tanstack/vue-table'
 import { groupBy, uniqBy } from 'lodash-es'
 import type { Assignment, Cluster, Label, QueueItem, RpcPerson } from '~/purple_client'
-import { calculatePeopleWorkload } from '~/utils/queue'
-import type { QueueTabId, AssignmentMessageProps } from '~/utils/queue'
+import { calculatePeopleWorkload, calculateEnqueuedAtData, renderEnqueuedAt } from '~/utils/queue'
+import { type QueueTabId, type AssignmentMessageProps } from '~/utils/queue'
 import { ANCHOR_STYLE } from '~/utils/html'
 import { useSiteStore } from '@/stores/site'
 import { overlayModalKey } from '~/providers/providerKeys'
@@ -211,19 +211,8 @@ const columns = [
         const value = data.getValue()
         if (!value) return ''
 
-        const enqueuedAt = DateTime.fromJSDate(value)
-        const now = DateTime.now()
-        const diffInDays = now.diff(enqueuedAt, 'days').days
-        const weeksInQueue = Math.floor(diffInDays / 7 * 2) / 2 // Floor to nearest 0.5
-
-        return h(
-          'div',
-          { class: 'text-xs' },
-          value ? [
-            h('div', enqueuedAt.toISODate() ?? ''),
-            h('div', `(${weeksInQueue} week${weeksInQueue !== 1 ? 's' : ''})`)
-          ] : []
-        )
+        const enqueuedAtData = calculateEnqueuedAtData(value)
+        return renderEnqueuedAt(enqueuedAtData)
       },
       sortingFn: (rowA, rowB, columnId) => {
         const now = DateTime.now()

--- a/client/app/utils/queue.ts
+++ b/client/app/utils/queue.ts
@@ -1,5 +1,7 @@
-import type { Assignment, Cluster, Label, QueueItem, SimpleCluster } from '~/purple_client'
+import { h } from 'vue'
+import type { Assignment, Cluster, Label, QueueItem, RfcToBe, SimpleCluster } from '~/purple_client'
 import type { Tab } from './tab'
+import { DateTime } from 'luxon'
 
 export const queueTabs: Tab[] = [
   {
@@ -79,16 +81,16 @@ export const sortCluster = (
 
 export type AssignmentMessageProps =
   | {
-      type: 'assign'
-      role: Assignment['role']
-      rfcToBeId: number
-    }
+    type: 'assign'
+    role: Assignment['role']
+    rfcToBeId: number
+  }
   | {
-      type: 'change'
-      assignments: Assignment[]
-      role: Assignment['role']
-      rfcToBeId: number
-    }
+    type: 'change'
+    assignments: Assignment[]
+    role: Assignment['role']
+    rfcToBeId: number
+  }
 
 export type RpcPersonWorkload = {
   personId: number
@@ -138,4 +140,21 @@ export const calculatePeopleWorkload = (clusters: Cluster[], queueItems: Pick<Qu
   })
 
   return peopleWorkload
+}
+
+export const calculateEnqueuedAtData = (enqueuedAtJSDate: Date) => {
+  const enqueuedAt = DateTime.fromJSDate(enqueuedAtJSDate)
+  const now = DateTime.now()
+  const diffInDays = now.diff(enqueuedAt, 'days').days
+  const weeksInQueue = Math.floor(diffInDays / 7 * 2) / 2 // Floor to nearest 0.5
+  return { enqueuedAt, diffInDays, weeksInQueue }
+}
+
+export const renderEnqueuedAt = ({ enqueuedAt, weeksInQueue }: ReturnType<typeof calculateEnqueuedAtData>) => {
+  return h('div',
+    { class: 'text-xs' },
+    [
+      h('div', enqueuedAt.toISODate() ?? ''),
+      h('div', `(${weeksInQueue} week${weeksInQueue !== 1 ? 's' : ''})`)
+    ])
 }


### PR DESCRIPTION
## feat

* adding additional fields to cluster reorder. These fields aren't complete but it's far as I got by the end of the day.
  * fyi @rudimatz @jennifer-richards now that we're aiming to display parts of the queue on the cluster page it would be useful if `queueList()` took a cluster number param to filter on

*screenshot*
<img width="813" height="348" alt="Screenshot_2025-12-17_17-52-37" src="https://github.com/user-attachments/assets/4612a20d-f980-434d-84a0-099db5469809" />

