### PR TITLE
fix: drafts in graph not always properly tagged

### DIFF
--- a/client/app/components/DocumentDependenciesGraph.vue
+++ b/client/app/components/DocumentDependenciesGraph.vue
@@ -124,14 +124,16 @@ const setTooltip: SetTooltip = (props) => {
 const hasMounted = ref(false)
 
 const rfcsByDraftName = computed(() => {
-  const result: Record<string, RfcToBe> = {};
+  const result: Record<string, RfcToBe> = {}
   if (props.rfcsToBe) {
     for (const rfcToBe of props.rfcsToBe) {
-      if (rfcToBe.name) result[rfcToBe.name] = rfcToBe;
+      if (rfcToBe.name) {
+        result[rfcToBe.name] = rfcToBe
+      }
     }
   }
-  return result;
-});
+  return result
+})
 
 const clusterGraphData = computed(() => {
 


### PR DESCRIPTION
instead of using `uniq` and using the first of multiple elements with same ID, I rather want to merge the properties of all those elements

fixes issue of e.g. https://purple.staging.ietf.org/clusters/562/, where `draft-ietf-bfd-optimizing-authentication` is received, but displayed as not received

<img width="738" height="482" alt="image" src="https://github.com/user-attachments/assets/0d1701a2-922c-4b43-a200-2c764970276d" />

fixes https://github.com/ietf-tools/purple/issues/738