### PR TITLE
feat: queue publish

### DIFF
--- a/client/app/components/DocHeader.vue
+++ b/client/app/components/DocHeader.vue
@@ -33,12 +33,6 @@
               <Icon name="ei:spinner-3" size="1.3rem" class="animate-spin" />
             </span>
           </BaseButton>
-          <BaseButton @click="openPublishModal" class="flex items-center">
-            <span> Publish</span>
-            <span v-if="isLoadingPublishModal" class="w-3">
-              <Icon name="ei:spinner-3" size="1.3rem" class="animate-spin" />
-            </span>
-          </BaseButton>
         </div>
       </div>
     </div>

--- a/client/app/components/PublishModal.vue
+++ b/client/app/components/PublishModal.vue
@@ -4,11 +4,11 @@
       <h1 class="text-xl font-bold pt-4 px-4 py-3">
         Publish
         <span class="text-2xl mx-1 font-mono whitespace-nowrap">
-          <span class="font-bold">RFC</span> {{ props.rfcToBe.rfcNumber }}
+          <span class="font-bold">RFC</span> {{ props.queueItem.rfcNumber }}
         </span>?
         <span class="text-sm text-gray-700 dark:text-gray-300">
           <br />
-          (<span class="font-mono">{{ props.rfcToBe.name }}</span>)
+          (<span class="font-mono">{{ props.queueItem.name }}</span>)
         </span>
       </h1>
 
@@ -62,7 +62,7 @@
           </ul>
         </BaseCard>
       </div>
-      <DocInfoCard is-read-only :rfc-to-be="props.rfcToBe" :draft-name="props.rfcToBe.name ?? ''"
+      <DocInfoCard is-read-only :rfc-to-be="rfcToBe" :draft-name="rfcToBe.name ?? ''"
         @refresh="props.onSuccess" />
     </div>
     <div class="border-t-1 border-gray-800 flex justify-end items-center">
@@ -75,15 +75,17 @@
 <script setup lang="ts">
 import { BaseButton } from '#components'
 import { overlayModalKey } from '~/providers/providerKeys';
-import type { Label, RfcToBe } from '~/purple_client';
+import type { Label, QueueItem } from '~/purple_client';
 
 type Props = {
-  rfcToBe: RfcToBe
+  queueItem: QueueItem
   labels: Label[]
   onSuccess: () => void
 }
 
 const props = defineProps<Props>()
+
+const rfcToBe = computed(() => queueItemToRfcToBe(props.queueItem))
 
 const overlayModalKeyInjection = inject(overlayModalKey)
 
@@ -97,7 +99,7 @@ const complexityItems = computed(() => {
     if (typeof id !== 'number') {
       throw Error('Expected label id to be a number')
     }
-    return props.rfcToBe.labels.includes(id) && label.isComplexity
+    return props.queueItem.labels?.some(label => label.id === id) && label.isComplexity
   })
 })
 
@@ -129,7 +131,7 @@ const api = useApi()
 const { closeOverlayModal } = overlayModalKeyInjection
 
 const handlePublish = async () => {
-  const { name } = props.rfcToBe
+  const { name } = props.queueItem
 
   if (name === undefined) {
     snackbar.add({

--- a/client/app/pages/queue/publish.vue
+++ b/client/app/pages/queue/publish.vue
@@ -1,0 +1,261 @@
+<template>
+  <div>
+    <TitleBlock title="Queue" summary="Where the magic happens.">
+    </TitleBlock>
+
+    <QueueTabs :current-tab="currentTab" />
+
+    <ErrorAlert v-if="error">
+      {{ error }}
+    </ErrorAlert>
+
+    <RpcTable>
+      <RpcThead>
+        <tr v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
+          <RpcTh v-for="header in headerGroup.headers" :key="header.id" :colSpan="header.colSpan"
+            :is-sortable="header.column.getCanSort()" :sort-direction="header.column.getIsSorted()"
+            :column-name="getVNodeText(header.column.columnDef.header)"
+            @click="header.column.getToggleSortingHandler()?.($event)">
+            <div class="flex items-center gap-2">
+              <FlexRender v-if="!header.isPlaceholder" :render="header.column.columnDef.header"
+                :props="header.getContext()" />
+            </div>
+          </RpcTh>
+        </tr>
+      </RpcThead>
+      <RpcTbody>
+        <RpcRowMessage :status="[status]" :column-count="table.getAllColumns().length"
+          :row-count="table.getRowModel().rows.length" />
+        <tr v-for="row in table.getRowModel().rows" :key="row.id">
+          <RpcTd v-for="cell in row.getVisibleCells()" :key="cell.id">
+            <FlexRender :render="cell.column.columnDef.cell" :props="cell.getContext()" />
+          </RpcTd>
+        </tr>
+      </RpcTbody>
+      <RpcTfoot>
+        <tr v-for="footerGroup in table.getFooterGroups()" :key="footerGroup.id">
+          <RpcTh v-for="header in footerGroup.headers" :key="header.id" :colSpan="header.colSpan">
+            <FlexRender v-if="!header.isPlaceholder" :render="header.column.columnDef.footer"
+              :props="header.getContext()" />
+          </RpcTh>
+        </tr>
+      </RpcTfoot>
+    </RpcTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Anchor, BaseButton, Icon, RpcLabel } from '#components'
+import {
+  FlexRender,
+  getCoreRowModel,
+  useVueTable,
+  createColumnHelper,
+  getFilteredRowModel,
+  getSortedRowModel,
+} from '@tanstack/vue-table'
+import type { SortingState } from '@tanstack/vue-table'
+import type { Label, QueueItem, RfcToBe } from '~/purple_client'
+import { type QueueTabId } from '~/utils/queue'
+import { ANCHOR_STYLE } from '~/utils/html'
+import { overlayModalKey } from '~/providers/providerKeys'
+import PublishModal from '~/components/PublishModal.vue'
+
+const api = useApi()
+const currentTab: QueueTabId = 'publish'
+
+const {
+  data,
+  status,
+  pending,
+  refresh,
+  error,
+} = await useAsyncData(
+  'queue2-queue',
+  () => api.queueList(),
+  {
+    server: false,
+    lazy: true,
+    default: () => [] as QueueItem[],
+  }
+)
+
+const {
+  data: labelsData,
+  status: labelsStatus,
+  pending: labelsPending,
+  refresh: labelsRefresh,
+  error: labelsError,
+} = await useAsyncData(
+  'queueList',
+  () => api.queueList(),
+  {
+    server: false,
+    lazy: true,
+    default: () => [] as Label[],
+  }
+)
+
+const columnHelper = createColumnHelper<QueueItem>()
+
+const sorting = ref<SortingState>([])
+
+const columns = [
+  columnHelper.display({
+    id: 'icon',
+    header: '',
+    cell: () => h(Icon, { name: "uil:file-alt", size: "1.25em", class: "text-gray-400 dark:text-neutral-500 mr-2" })
+  }),
+  columnHelper.accessor('name', {
+    header: 'Document',
+    cell: data => {
+      return h(Anchor, { href: `/docs/${data.row.original.name}`, 'class': ANCHOR_STYLE }, () => [
+        data.getValue(),
+      ])
+    },
+    sortingFn: 'alphanumeric',
+  }),
+  columnHelper.accessor('rfcNumber', {
+    header: 'RFC Number',
+    cell: data => data.getValue(),
+    sortingFn: 'alphanumeric',
+    sortUndefined: 'last',
+  }),
+  columnHelper.accessor(
+    'labels', {
+    header: 'Labels',
+    cell: data => {
+      const labels = data.getValue()
+      if (!labels) return undefined
+      return h('span', labels.map(label => h(RpcLabel, { label, class: 'ml-2' })))
+    },
+    enableSorting: false,
+  }),
+  columnHelper.accessor(
+    'cluster',
+    {
+      header: 'Cluster',
+      cell: data => {
+        const value = data.getValue()
+        if (!value) {
+          return undefined
+        }
+        return h(
+          Anchor,
+          { href: `/clusters/${value.number}` },
+          () => [
+            h(Icon, { name: 'pajamas:group', class: 'h-5 w-5 inline-block mr-1' }),
+            String(value.number)
+          ]
+        )
+      },
+      sortingFn: (rowA, rowB) => sortCluster(rowA.original.cluster, rowB.original.cluster),
+    }
+  ),
+  columnHelper.display({
+    header: 'Actions',
+    cell: (data) => {
+      const { original } = data.row
+      const { id } = original
+      if (!id) {
+        console.error({ queueItem: original })
+        throw Error("Expected queueItem to have `id`")
+      }
+      const isLoading = Boolean(isLoadingPublishModal.value[id])
+      console.log("isLoadingPublishModal.value[id]", isLoading, isLoadingPublishModal.value[id], isLoadingPublishModal.value, isLoadingPublishModal)
+      return h(
+        BaseButton,
+        { 'onClick': () => openPublishModal(data.row.original), class:"flex items-center" },
+        () => [
+          h('span', 'Publish'),
+          isLoading && h('span', { class: 'w-3' }, [
+            h(Icon, { name: 'ei:spinner-3', size:'1.3rem', class: 'animate-spin' })
+          ])
+        ]
+      )
+    }
+  })
+]
+
+const table = useVueTable({
+  get data() {
+    return data.value
+  },
+  columns,
+  state: {
+    get sorting() {
+      return sorting.value
+    },
+  },
+  getCoreRowModel: getCoreRowModel(),
+  getFilteredRowModel: getFilteredRowModel(),
+  getSortedRowModel: getSortedRowModel(),
+  onSortingChange: updaterOrValue => {
+    sorting.value =
+      typeof updaterOrValue === 'function'
+        ? updaterOrValue(sorting.value)
+        : updaterOrValue
+  },
+})
+
+const isLoadingPublishModal = ref<Record<number, boolean>>({})
+
+const snackbar = useSnackbar()
+
+const overlayModal = inject(overlayModalKey)
+
+const openPublishModal = async (queueItem: QueueItem) => {
+  console.log("openPublishModal", queueItem )
+  if (!overlayModal) {
+    throw Error("Should have overlay modal context")
+  }
+  if(labelsData.value.length === 0) {
+    snackbar.add({
+      type: "info",
+      text: `Still loading labels, please wait...`
+    })
+  }
+
+  const { openOverlayModal } = overlayModal
+
+  const { id } = queueItem
+
+  if (!id) {
+    console.error({ queueItem })
+    throw Error('Expected rfcToBe to have an id')
+  }
+
+  isLoadingPublishModal.value = {
+    ...isLoadingPublishModal.value,
+    [id]: true
+  }
+
+  try {
+    openOverlayModal({
+      component: PublishModal,
+      componentProps: {
+        queueItem,
+        labels: labelsData.value,
+        onSuccess: () => { }
+      },
+    }).catch(e => {
+      if (e === undefined) {
+        isLoadingPublishModal.value = {
+          ...isLoadingPublishModal.value,
+          [id]: false
+        }
+        // ignore... it's just signalling that the modal has closed
+      } else {
+        console.error(e)
+        throw e
+      }
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+useHead({
+  title: 'RPC Publish Queue'
+})
+</script>

--- a/client/app/utils/convert.ts
+++ b/client/app/utils/convert.ts
@@ -1,0 +1,51 @@
+import type { QueueItem, RfcToBe } from "~/purple_client";
+
+type _MissingKeys = keyof Omit<Record<keyof RfcToBe, boolean>, keyof QueueItem>
+
+/**
+ * There is no 1:1 conversion between QueueItem and RfcToBe so this should only be used
+ * when the missing props don't matter. A list of missing props can be viewed by devs
+ * with the `_MissingKeys` type above, and the return value of ''
+ */
+export const queueItemToRfcToBe = (queueItem: QueueItem): RfcToBe => {
+  const {
+    id,
+    name,
+    disposition,
+    externalDeadline,
+    internalGoal,
+    labels,
+    cluster,
+    assignmentSet,
+    actionholderSet,
+    pendingActivities,
+    rfcNumber,
+    ianaStatus,
+  } = queueItem
+
+  return {
+    id,
+    name,
+    disposition,
+    externalDeadline,
+    internalGoal,
+    labels: labels?.map(label => label.id).filter(id => typeof id === 'number') ?? [],
+    cluster,
+    authors: [],
+    assignmentSet,
+    actionholderSet,
+    pendingActivities,
+    rfcNumber,
+    publishedAt: null,
+    consensus: undefined,
+    subseries: undefined,
+    ianaStatus,
+    submittedFormat: '',
+    submittedBoilerplate: '',
+    submittedStdLevel: '',
+    submittedStream: '',
+    intendedBoilerplate: '',
+    intendedStdLevel: '',
+    intendedStream: ''
+  }
+}

--- a/client/app/utils/queue.ts
+++ b/client/app/utils/queue.ts
@@ -3,7 +3,7 @@ import type { Assignment, Cluster, Label, QueueItem, RfcToBe, SimpleCluster } fr
 import type { Tab } from './tab'
 import { DateTime } from 'luxon'
 
-export const queueTabs: Tab[] = [
+export const queueTabs = [
   {
     id: 'submissions',
     name: 'Submissions',
@@ -23,6 +23,12 @@ export const queueTabs: Tab[] = [
     icon: 'uil:clock'
   },
   {
+    id: 'publish',
+    name: 'Publish',
+    to: '/queue/publish',
+    icon: 'uil:trophy'
+  },
+  {
     id: 'published',
     name: 'Recently Published',
     to: '/queue/published',
@@ -31,6 +37,9 @@ export const queueTabs: Tab[] = [
 ] as const satisfies Tab[]
 
 export type QueueTabId = (typeof queueTabs)[number]['id']
+
+// @ts-expect-error
+const _queueId: QueueTabId = 'an-id-that-does-not-exist'
 
 export const sortDate = (
   dateA: Date | undefined | null,


### PR DESCRIPTION
## feat

* Adds a new queue tab route named 'Publish'. Removes the 'publish' button from doc info, and adds a similar feature to the table on this new route.

*screenshot*
<img width="1903" height="870" alt="Screenshot_2026-01-13_21-49-20" src="https://github.com/user-attachments/assets/0e96ec23-551b-42e5-b8d8-9e07ee571d39" />
