### PR TITLE
fix: failing import PublishModal

### DIFF
--- a/client/app/components/DocHeader.vue
+++ b/client/app/components/DocHeader.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { AssignmentFinishedModal, EmailModal, PublishModal } from '#components';
+import { AssignmentFinishedModal, EmailModal } from '#components';
 import { overlayModalKey } from '~/providers/providerKeys';
 import type { MailTemplate, RfcToBe, RpcPerson } from '~/purple_client';
 


### PR DESCRIPTION
relates to https://github.com/ietf-tools/purple/pull/813

component `PublishModal ` was removed but is still imported