### PR TITLE
fix: error handling of loading rfc in pub prep

### DIFF
--- a/client/app/components/DiffTable.vue
+++ b/client/app/components/DiffTable.vue
@@ -35,12 +35,10 @@
           </td>
         </tr>
         <tr v-if="row.rowValue.detail && row.rowValue.detail.length > 0">
-          <tr>
-            <td colspan="3" className="bg-yellow-200 text-yellow-900">
-              <Icon name="uil:info-circle" size="0.8rem" class="mr-2" />
-              {{ row.rowValue.detail }}
-            </td>
-          </tr>
+          <td colspan="3" className="bg-yellow-200 text-yellow-900">
+            <Icon name="uil:info-circle" size="0.8rem" class="mr-2" />
+            {{ row.rowValue.detail }}
+          </td>
         </tr>
       </template>
     </tbody>


### PR DESCRIPTION
## fix

* pub prep loads an `rfcToBe` initially to check whether it's `disposition: 'published'`  however errors weren't handled, so this PR fixes that