### PR TITLE
fix: doc info duplicate values, and read only

### DIFF
--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -1,7 +1,7 @@
 <template>
   <BaseCard>
     <template #header>
-      <CardHeader title="Document Info" />
+      <CardHeader :title="`Document Info${props.isReadOnly ? ' (read only)' : ''}`" />
     </template>
     <div v-if="rfcToBe">
       <DescriptionList>
@@ -31,7 +31,7 @@
                   </div>
                 </div>
               </div>
-              <div>
+              <div v-if="!props.isReadOnly">
                 <Anchor :href="draftAssignmentsHref(props.rfcToBe?.name, 'edit-authors')"
                   :class="[classForBtnType.outline, 'px-2 py-1']">
                   <Icon name="uil:pen" />

--- a/client/app/components/PatchRfcToBeField.vue
+++ b/client/app/components/PatchRfcToBeField.vue
@@ -3,7 +3,7 @@
     <template v-if="isReadOnly">
       <slot />
     </template>
-    <template v-if="!isEditing">
+    <template v-else-if="!isEditing">
       <div class="flex-1">
         <slot />
       </div>


### PR DESCRIPTION
## fix

* when a document was read only the field values were being shown twice, and the read-only status of editors wasn't used

fixes #837