### PR TITLE
chore(deps): update to postgresql-client-17

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update --fix-missing && apt-get install -qy \
 	nano \
 	netcat-openbsd \
 	nodejs \
-	postgresql-client-14 \
+	postgresql-client-17 \
 	unzip \
 	wget \
 	zsh


### PR DESCRIPTION
Also triggers a base image rebuild that should fix node installation due to SHA1 signatures being deprecated by apt as of 2026-02-01