### PR TITLE
fix: default MetadataValidationResultsList action

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -1608,35 +1608,6 @@ class MetadataValidationResultsViewSet(viewsets.ModelViewSet):
         )
 
     @extend_schema(
-        operation_id="metadata_validation_results_list",
-        parameters=[
-            OpenApiParameter(
-                name="draft_name",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.PATH,
-                description="Draft name",
-            ),
-        ],
-        responses={
-            200: MetadataValidationResultsSerializer,
-        },
-    )
-    def list(self, request, *args, **kwargs):
-        """Return single metadata validation result for this draft"""
-        draft_name = kwargs.get("draft_name")
-        try:
-            mvr = MetadataValidationResults.objects.get(
-                rfc_to_be__draft__name=draft_name
-            )
-            serializer = self.get_serializer(mvr)
-            return Response(serializer.data)
-        except MetadataValidationResults.DoesNotExist:
-            return Response(
-                {"error": "No MetadataValidationResults for draft found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
-    @extend_schema(
         operation_id="metadata_validation_results_create",
         parameters=[
             OpenApiParameter(


### PR DESCRIPTION
Returns a list of `MetadataValidationResult` values from `documentsMetadataValidationResultsList()`, which should match the types in the client.

For now at least, the return value will always have 0 or 1 elements. However, I suggest we treat it as though it _may_ return more than one, ordered from newest to oldest, so use `results[0]` ("first") rather than `results[-1]` ("last") for processing.