### PR TITLE
fix: wrong query to get blocked reasons

### DIFF
--- a/rpc/lifecycle/blocked_assignments.py
+++ b/rpc/lifecycle/blocked_assignments.py
@@ -50,7 +50,7 @@ def get_block_reasons(rfc: RfcToBe) -> set[str]:
             reasons.add(BlockingReason.LABEL_AUTHOR_INPUT_REQUIRED)
         # any related documents not received (incl. 2g/3g), return only first
         if rfc.rpcrelateddocument_set.filter(
-            relationship__slug=DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUGS
+            relationship__slug__in=DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUGS
         ).exists():
             if rfc.rpcrelateddocument_set.filter(
                 relationship__slug=DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/877

draft that should have been blocked was not blocked (e.g. https://purple.staging.ietf.org/docs/draft-ietf-suit-manifest)