### PR TITLE
fix: unsquash faces

### DIFF
--- a/client/app/components/HeaderNav.vue
+++ b/client/app/components/HeaderNav.vue
@@ -64,7 +64,7 @@
         <HeadlessMenu v-if="userStore.authenticated" as="div" class="relative">
           <HeadlessMenuButton class="-m-1.5 flex items-center p-1.5">
             <span class="sr-only">Open user menu</span>
-            <img class="w-8 rounded-full bg-gray-50" :src="userStore.avatar ?? undefined" alt="" >
+            <img class="h-8 max-w-16 rounded-full bg-gray-50" :src="userStore.avatar ?? undefined" alt="" >
             <span class="hidden lg:flex lg:items-center">
               <span class="ml-4 text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-300" aria-hidden="true">{{ userStore.name }}</span>
               <Icon name="uil:angle-down" class="ml-2 h-5 w-5 text-gray-400 dark:text-neutral-400" aria-hidden="true" />


### PR DESCRIPTION
## fix

* unsquash faces. rather than setting both dimensions this sets the height (as height stretching the container would be the most awkward UI impact). There is also a **max** width set so that extremely wide and short images don't break the container layout and this would necessarily squash the face.

**screenshots**

square ratio profile image
*before*
<img width="366" height="120" alt="Screenshot_2026-02-19_15-06-20" src="https://github.com/user-attachments/assets/58114c95-e0bc-43c4-84d2-21814f9130f7" />

*after*
<img width="365" height="120" alt="Screenshot_2026-02-19_15-08-33" src="https://github.com/user-attachments/assets/173f5640-802f-4662-8bb1-73881fd22d9b" />

portrait ratio profile image
*before*
<img width="342" height="98" alt="Screenshot_2026-02-19_15-16-47" src="https://github.com/user-attachments/assets/02c66ffb-8762-4c0a-a47a-4cc947fcb6da" />

*after*
<img width="369" height="106" alt="Screenshot_2026-02-19_15-17-28" src="https://github.com/user-attachments/assets/a25cfec2-7173-4959-91ca-88c398a821a2" />
