### PR TITLE
feat: Add subseries information to rfc-index.txt

### DIFF
--- a/rpc/rfcindex.py
+++ b/rpc/rfcindex.py
@@ -88,10 +88,20 @@ def get_rfc_text_index_entries():
 
             doc_relations = f"{obsoletes}{obsoleted_by}{updates}{updated_by} "
 
+            # subseries
+            subseries = ",".join(
+                [
+                    f"{s.type_id.upper()}{s.number:04d}"
+                    for s in rfc.subseriesmember_set.all()
+                ]
+            )
+            if subseries:
+                subseries = f"(Also {subseries}) "
+
             entry = fill(
                 (
                     f"{rfc.rfc_number:04d} {rfc.title}. {authors}. {date}. "
-                    f"(Format: {formats}){doc_relations}"
+                    f"(Format: {formats}){doc_relations}{subseries}"
                     f"(Status: {str(rfc.publication_std_level).upper()}) "
                     f"(DOI: {settings.DOI_PREFIX}/RFC{rfc.rfc_number:04d})"
                 ),


### PR DESCRIPTION
Resulting `rfc-index.txt` (with sample formats): [rfc-index.txt](https://t4.fq.nz/purple.843/rfc-index.txt)
Diff with production `rfc-index.txt`: [HTML diff](https://t4.fq.nz/purple.843/diff.html)