### PR TITLE
feat: area for Document / RfcToBe

### DIFF
--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -123,6 +123,11 @@ class Document(models.Model):
         return self._fetch("shepherd")
 
     @property
+    def area(self) -> str:
+        area = self._fetch("area")
+        return "" if area is None else area.acronym
+
+    @property
     def ad(self) -> str:
         return self._fetch("ad")
 

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -330,6 +330,10 @@ class RfcToBe(models.Model):
             return f"RFC {self.rfc_number}"
         return f"<RfcToBe {self.pk}>"
 
+    @property
+    def area(self) -> str:
+        return "" if self.draft is None else self.draft.area
+
     # Easier interface to the cluster_set
     @property
     def cluster(self) -> "Cluster | None":


### PR DESCRIPTION
Adds `area` property to `RfcToBe` and `datatracker.Document`. Fetches the acronym from datatracker, returning `""` if there is no area (e.g., for an `RfcToBe` without a draft or in a non-IETF-stream group).

Does not patch the value through to the front end anywhere, but it's available in the back end as `rfctobe.area`.

Needs https://github.com/ietf-tools/datatracker/pull/10487