### PR TITLE
fix: update purple yaml

### DIFF
--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -729,8 +729,6 @@ paths:
       responses:
         '200':
           description: No response body
-        '400':
-          description: No response body
   /api/rpc/documents/{draft_name}/action_holders/:
     get:
       operationId: documents_action_holders_list


### PR DESCRIPTION
fix related to https://github.com/ietf-tools/purple/pull/921 (re-generated purple yaml was not commited)