### PR TITLE
fix: loading indicator

### DIFF
--- a/client/app/components/RpcRowMessage.vue
+++ b/client/app/components/RpcRowMessage.vue
@@ -28,18 +28,20 @@ type Props = {
   rowCount: number
   columnCount: number
   status: Status | Status[]
-  error: Error | Error[]
+  error?: Error | Error[]
 }
 
 const props = defineProps<Props>()
 
 const statusArr = computed(() => {
   const { status } = props
+  if (!status) return []
   return Array.isArray(status) ? status : [status]
 })
 
 const errorArr = computed(() => {
   const { error } = props
+  if (!error) return []
   return Array.isArray(error) ? error : [error]
 })
 </script>

--- a/client/app/pages/queue/queue.vue
+++ b/client/app/pages/queue/queue.vue
@@ -94,7 +94,7 @@
         </tr>
       </RpcThead>
       <RpcTbody>
-        <RpcRowMessage :status="[status, clustersStatus, peopleStatus]" :column-count="table.getAllColumns().length"
+        <RpcRowMessage :status="[status, clustersStatus, peopleStatus]" :error="[error, clustersError, peopleError]" :column-count="table.getAllColumns().length"
           :row-count="table.getRowModel().rows.length" />
         <tr v-for="row in table.getRowModel().rows" :key="row.id">
           <RpcTd v-for="cell in row.getVisibleCells()" :key="cell.id">


### PR DESCRIPTION
## fix

* loading indicator would show 'no rows found' while still loading, but now it waits until all api calls are successful before saying such a thing