### PR TITLE
chore: direct link to queue/queue rather than the queue redirect

### DIFF
--- a/client/app/components/SidebarNav.vue
+++ b/client/app/components/SidebarNav.vue
@@ -124,7 +124,7 @@ type Navigation = {
 }
 
 const navigation: Navigation[] = [
-  { name: 'Queue', href: '/queue', icon: h(Icon, { name: 'solar:layers-minimalistic-bold-duotone' }) },
+  { name: 'Queue', href: '/queue/queue', icon: h(Icon, { name: 'solar:layers-minimalistic-bold-duotone' }) },
   { name: 'My Documents', href: '/docs', icon: h(Icon, { name: 'solar:documents-minimalistic-line-duotone' }) },
   { name: 'Team', href: '/team', icon: h(Icon, { name: 'solar:users-group-rounded-bold-duotone' }) },
   { name: 'Final Review', href: '/final-review', icon: h(Icon, { name: 'solar:diploma-verified-broken' }) }


### PR DESCRIPTION
## chore

* the sidebar linked to `/queue` which is a route that redirects to `/queue/queue` so instead let's just directly link to `/queue/queue` to make it faster