### PR TITLE
fix: show DT person id for author search results

### DIFF
--- a/client/app/components/EditAuthorsAdd.vue
+++ b/client/app/components/EditAuthorsAdd.vue
@@ -30,7 +30,7 @@
             {{ searchResult.name }}
           </span>
           <span class="font-normal ml-1" v-if="searchResult.personId">
-            {{ SPACE }}{{ ` #${searchResult.email ?? ''}` }}
+            {{ SPACE }}{{ ` #${searchResult.personId ?? ''}` }}
           </span>
         </ComboboxItem>
       </ComboboxViewport>


### PR DESCRIPTION

<img width="277" height="157" alt="image" src="https://github.com/user-attachments/assets/f36bfdfe-b0ef-41e8-a601-8db2a69e91c9" />


resolves https://github.com/ietf-tools/purple/issues/469