### PR TITLE
fix: cluster graph isNormRef

### DIFF
--- a/client/app/components/DocumentDependenciesGraph.vue
+++ b/client/app/components/DocumentDependenciesGraph.vue
@@ -220,7 +220,7 @@ const clusterGraphData = computed(() => {
         isReceived: isReceived ?? undefined,
         disposition: parseDisposition(disposition),
         isBlocked,
-        isNormRef: false,
+        isNormRef: true,
         hasNormRef,
         hasNormRefInQueue,
         hasNormRefBlocked


### PR DESCRIPTION
## fix

* cluster graph `isNormRef` was set to `false`, but now `true`