### PR TITLE
feat: add deep references (2G, 3G)

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -504,6 +504,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
             # check for existing references where the new draft is the target
             # if "not-received" references exist, change them to "refqueue"
             # if "not-received-2/3g" references exist, delete them
+            recompute_source_ids: set[int] = set()
             existing_references = RpcRelatedDocument.objects.filter(
                 target_document__name=rfctobe.draft.name,
                 relationship__slug__in=(
@@ -520,7 +521,26 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                     )
                     existing_reference.save()
                 else:
+                    if (
+                        existing_reference.relationship.slug
+                        == DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG
+                    ):
+                        # schedule recomputation to clean up deleted 2G references.
+                        recompute_source_ids.add(existing_reference.source_id)
                     existing_reference.delete()
+
+            for source_id in recompute_source_ids:
+                ref_1g = RpcRelatedDocument.objects.filter(
+                    source_id=source_id,
+                    relationship__slug__in=[
+                        DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG,
+                        DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG,
+                    ],
+                ).first()
+                if ref_1g:
+                    transaction.on_commit(
+                        lambda pk=ref_1g.pk: compute_deep_references_task.delay(pk)
+                    )
 
             # Find normative references and store them as RelatedDocs
             # Get ref list from Datatracker

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -130,6 +130,7 @@ from .serializers import (
     check_user_has_role,
 )
 from .tasks import (
+    compute_deep_references_task,
     publish_rfctobe_task,
     send_mail_task,
     set_stream_manager_task,
@@ -1320,6 +1321,30 @@ class RpcDocumentReferencesViewSet(viewsets.ModelViewSet):
                 relationship__slug__in=DocRelationshipName.REFERENCE_RELATIONSHIP_SLUGS,
             )
         )
+
+    def perform_destroy(self, instance):
+        source = instance.source
+        instance.delete()
+        # Recompute 2G/3G from the remaining 1G relationships whenever one gets removed
+        remaining = RpcRelatedDocument.objects.filter(
+            source=source,
+            relationship__slug__in=[
+                DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG,
+                DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG,
+            ],
+        ).first()
+        if remaining:
+            compute_deep_references_task.delay(remaining.pk)
+        else:
+            # No 1G refs remain — delete all auto-computed 2G/3G directly, because they
+            # can't exist without a 1G ref
+            RpcRelatedDocument.objects.filter(
+                source=source,
+                relationship__slug__in=[
+                    DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG,
+                    DocRelationshipName.NOT_RECEIVED_3G_RELATIONSHIP_SLUG,
+                ],
+            ).delete()
 
 
 @extend_schema_with_draft_name()

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -52,6 +52,7 @@ from .models import (
     SubseriesTypeName,
     UnusableRfcNumber,
 )
+from .tasks import compute_deep_references_task
 from .utils import add_doc_to_cluster, create_cluster
 
 
@@ -1045,6 +1046,12 @@ class CreateRpcRelatedDocumentSerializer(RpcRelatedDocumentSerializer):
             raise serializers.ValidationError(
                 f"Failed to create related document due to a database constraint: {err}"
             ) from err
+
+        if relationship.slug in (
+            DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG,
+            DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG,
+        ):
+            compute_deep_references_task.delay(related_doc.id)
 
         return related_doc
 

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -209,104 +209,124 @@ def _compute_deep_references(
     *,
     rpcapi: rpcapi_client.PurpleApi,
 ) -> None:
-    """Compute 2nd and 3rd generation not-received references for an RfcToBe.
+    """Recompute all 2G and 3G not-received references for an RfcToBe source.
 
-    Given an existing RpcRelatedDocument (not-received or refqueue), fetches
-    the target's references from the Datatracker and creates not-received-2g
-    relationships for each, then fetches each 2nd-gen reference's references
-    and creates not-received-3g relationships.
-
-    Duplicates are avoided by checking for existing relationships before creating
-    new ones.
+    Called when a 1G (not-received or refqueue) relationship is created or
+    updated.  Deletes all existing auto-computed 2G/3G relationships for the
+    source and rebuilds them from scratch.
     """
-    related_doc = RpcRelatedDocument.objects.select_related(
-        "source",
-        "target_document",
-        "target_rfctobe__draft",
-    ).get(pk=related_doc_id)
+    related_doc = RpcRelatedDocument.objects.select_related("source").get(
+        pk=related_doc_id
+    )
     source = related_doc.source
 
-    if related_doc.target_document is not None:
-        target_datatracker_id = related_doc.target_document.datatracker_id
-    elif (
-        related_doc.target_rfctobe is not None
-        and related_doc.target_rfctobe.draft is not None
-    ):
-        target_datatracker_id = related_doc.target_rfctobe.draft.datatracker_id
-    else:
-        logger.warning("RpcRelatedDocument %d has no resolvable target", related_doc_id)
-        return
+    # Delete all previously auto-computed 2G/3G relations — rebuild from scratch.
+    RpcRelatedDocument.objects.filter(
+        source=source,
+        relationship__slug__in=[
+            DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG,
+            DocRelationshipName.NOT_RECEIVED_3G_RELATIONSHIP_SLUG,
+        ],
+    ).delete()
 
-    if target_datatracker_id is None:
-        logger.warning(
-            "RpcRelatedDocument %d target has no datatracker_id", related_doc_id
-        )
-        return
-
-    # Collect datatracker IDs already linked to this source to avoid duplicates
-    existing_target_dt_ids: set[int] = set(
+    # Fetch all current 1G relations for this source.
+    refs_1g = list(
         RpcRelatedDocument.objects.filter(
             source=source,
-            relationship__slug__in=DocRelationshipName.REFERENCE_RELATIONSHIP_SLUGS,
-            target_document__isnull=False,
-        ).values_list("target_document__datatracker_id", flat=True)
+            relationship__slug__in=[
+                DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG,
+                DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG,
+            ],
+        ).select_related("target_document", "target_rfctobe__draft")
     )
 
-    # Datatracker IDs of drafts that already have an active RfcToBe
-    active_rfctobe_dt_ids: set[int] = set(
+    # IDs of drafts that already have an active RfcToBe
+    received_dt_ids_list: set[int] = set(
         RfcToBe.objects.exclude(disposition_id="withdrawn")
         .filter(draft__datatracker_id__isnull=False)
         .values_list("draft__datatracker_id", flat=True)
     )
 
-    refs_2g = rpcapi.get_draft_references(target_datatracker_id) or []
-    for ref_2g in refs_2g:
-        if ref_2g.id in active_rfctobe_dt_ids or ref_2g.id in existing_target_dt_ids:
+    # Seed received_dt_ids with all 1G target IDs so they are not re-added as 2G/3G.
+    received_dt_ids: set[int] = set(received_dt_ids_list)
+    for ref in refs_1g:
+        if (
+            ref.target_document is not None
+            and ref.target_document.datatracker_id is not None
+        ):
+            received_dt_ids.add(ref.target_document.datatracker_id)
+        elif (
+            ref.target_rfctobe is not None
+            and ref.target_rfctobe.draft is not None
+            and ref.target_rfctobe.draft.datatracker_id is not None
+        ):
+            received_dt_ids.add(ref.target_rfctobe.draft.datatracker_id)
+
+    for ref in refs_1g:
+        if ref.target_document is not None:
+            target_dt_id = ref.target_document.datatracker_id
+        elif ref.target_rfctobe is not None and ref.target_rfctobe.draft is not None:
+            target_dt_id = ref.target_rfctobe.draft.datatracker_id
+        else:
+            logger.warning("1G RpcRelatedDocument %d has no resolvable target", ref.pk)
             continue
 
-        draft_2g = Document.objects.filter(
-            datatracker_id=ref_2g.id
-        ).first() or get_or_create_draft_by_name(ref_2g.name, rpcapi=rpcapi)
-        if draft_2g is None:
+        if target_dt_id is None:
             logger.warning(
-                "Could not get or create document for 2G reference %s (id=%d)",
-                ref_2g.name,
-                ref_2g.id,
+                "1G RpcRelatedDocument %d target has no datatracker_id", ref.pk
             )
             continue
 
-        RpcRelatedDocument.objects.get_or_create(
-            source=source,
-            relationship=DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG,
-            target_document=draft_2g,
-        )
-        existing_target_dt_ids.add(ref_2g.id)
+        refs_2g = rpcapi.get_draft_references(target_dt_id) or []
+        created_2g_ids: list[int] = []
 
-        refs_3g = rpcapi.get_draft_references(ref_2g.id) or []
-        for ref_3g in refs_3g:
-            if (
-                ref_3g.id in active_rfctobe_dt_ids
-                or ref_3g.id in existing_target_dt_ids
-            ):
+        for ref_2g in refs_2g:
+            # prevent duplicate processing of same 2G
+            if ref_2g.id in received_dt_ids:
                 continue
 
-            draft_3g = Document.objects.filter(
-                datatracker_id=ref_3g.id
-            ).first() or get_or_create_draft_by_name(ref_3g.name, rpcapi=rpcapi)
-            if draft_3g is None:
+            draft_2g = Document.objects.filter(
+                datatracker_id=ref_2g.id
+            ).first() or get_or_create_draft_by_name(ref_2g.name, rpcapi=rpcapi)
+            if draft_2g is None:
                 logger.warning(
-                    "Could not get or create document for 3G reference %s (id=%d)",
-                    ref_3g.name,
-                    ref_3g.id,
+                    "Could not get or create document for 2G reference %s (id=%d)",
+                    ref_2g.name,
+                    ref_2g.id,
                 )
                 continue
 
             RpcRelatedDocument.objects.get_or_create(
                 source=source,
-                relationship=DocRelationshipName.NOT_RECEIVED_3G_RELATIONSHIP_SLUG,
-                target_document=draft_3g,
+                relationship=DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG,
+                target_document=draft_2g,
             )
-            existing_target_dt_ids.add(ref_3g.id)
+            received_dt_ids.add(ref_2g.id)
+            created_2g_ids.append(ref_2g.id)
+
+        for ref_2g_id in created_2g_ids:
+            refs_3g = rpcapi.get_draft_references(ref_2g_id) or []
+            for ref_3g in refs_3g:
+                if ref_3g.id in received_dt_ids:
+                    continue
+
+                draft_3g = Document.objects.filter(
+                    datatracker_id=ref_3g.id
+                ).first() or get_or_create_draft_by_name(ref_3g.name, rpcapi=rpcapi)
+                if draft_3g is None:
+                    logger.warning(
+                        "Could not get or create document for 3G reference %s (id=%d)",
+                        ref_3g.name,
+                        ref_3g.id,
+                    )
+                    continue
+
+                RpcRelatedDocument.objects.get_or_create(
+                    source=source,
+                    relationship=DocRelationshipName.NOT_RECEIVED_3G_RELATIONSHIP_SLUG,
+                    target_document=draft_3g,
+                )
+                received_dt_ids.add(ref_3g.id)
 
 
 @shared_task

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -1,8 +1,11 @@
 # Copyright The IETF Trust 2025-2026, All Rights Reserved
+import rpcapi_client
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.db.models import F
 
+from datatracker.models import Document
+from datatracker.rpcapi import with_rpcapi
 from rpc.lifecycle.blocked_assignments import apply_blocked_assignment_for_rfc
 from utils.task_utils import RetryTask
 
@@ -14,8 +17,15 @@ from .lifecycle.publication import (
     publish_rfctobe,
 )
 from .lifecycle.repo import GithubRepository
-from .models import MailMessage, MetadataValidationResults, RfcToBe
+from .models import (
+    DocRelationshipName,
+    MailMessage,
+    MetadataValidationResults,
+    RfcToBe,
+    RpcRelatedDocument,
+)
 from .rfcindex import refresh_rfc_index
+from .utils import get_or_create_draft_by_name
 
 
 @shared_task
@@ -191,3 +201,122 @@ def update_blocked_assignments_for_in_progress_rfcs_task():
     """Process all in_progress RfcToBe instances to apply blocked assignments"""
     for rfc in RfcToBe.objects.filter(disposition_id="in_progress"):
         apply_blocked_assignment_for_rfc(rfc)
+
+
+@with_rpcapi
+def _compute_deep_references(
+    related_doc_id: int,
+    *,
+    rpcapi: rpcapi_client.PurpleApi,
+) -> None:
+    """Compute 2nd and 3rd generation not-received references for an RfcToBe.
+
+    Given an existing RpcRelatedDocument (not-received or refqueue), fetches
+    the target's references from the Datatracker and creates not-received-2g
+    relationships for each, then fetches each 2nd-gen reference's references
+    and creates not-received-3g relationships.
+
+    Duplicates are avoided by checking for existing relationships before creating
+    new ones.
+    """
+    related_doc = RpcRelatedDocument.objects.select_related(
+        "source",
+        "target_document",
+        "target_rfctobe__draft",
+    ).get(pk=related_doc_id)
+    source = related_doc.source
+
+    if related_doc.target_document is not None:
+        target_datatracker_id = related_doc.target_document.datatracker_id
+    elif (
+        related_doc.target_rfctobe is not None
+        and related_doc.target_rfctobe.draft is not None
+    ):
+        target_datatracker_id = related_doc.target_rfctobe.draft.datatracker_id
+    else:
+        logger.warning("RpcRelatedDocument %d has no resolvable target", related_doc_id)
+        return
+
+    if target_datatracker_id is None:
+        logger.warning(
+            "RpcRelatedDocument %d target has no datatracker_id", related_doc_id
+        )
+        return
+
+    # Collect datatracker IDs already linked to this source to avoid duplicates
+    existing_target_dt_ids: set[int] = set(
+        RpcRelatedDocument.objects.filter(
+            source=source,
+            relationship__slug__in=DocRelationshipName.REFERENCE_RELATIONSHIP_SLUGS,
+            target_document__isnull=False,
+        ).values_list("target_document__datatracker_id", flat=True)
+    )
+
+    # Datatracker IDs of drafts that already have an active RfcToBe
+    active_rfctobe_dt_ids: set[int] = set(
+        RfcToBe.objects.exclude(disposition_id="withdrawn")
+        .filter(draft__datatracker_id__isnull=False)
+        .values_list("draft__datatracker_id", flat=True)
+    )
+
+    refs_2g = rpcapi.get_draft_references(target_datatracker_id) or []
+    for ref_2g in refs_2g:
+        if ref_2g.id in active_rfctobe_dt_ids or ref_2g.id in existing_target_dt_ids:
+            continue
+
+        draft_2g = Document.objects.filter(
+            datatracker_id=ref_2g.id
+        ).first() or get_or_create_draft_by_name(ref_2g.name, rpcapi=rpcapi)
+        if draft_2g is None:
+            logger.warning(
+                "Could not get or create document for 2G reference %s (id=%d)",
+                ref_2g.name,
+                ref_2g.id,
+            )
+            continue
+
+        RpcRelatedDocument.objects.get_or_create(
+            source=source,
+            relationship=DocRelationshipName.NOT_RECEIVED_2G_RELATIONSHIP_SLUG,
+            target_document=draft_2g,
+        )
+        existing_target_dt_ids.add(ref_2g.id)
+
+        refs_3g = rpcapi.get_draft_references(ref_2g.id) or []
+        for ref_3g in refs_3g:
+            if (
+                ref_3g.id in active_rfctobe_dt_ids
+                or ref_3g.id in existing_target_dt_ids
+            ):
+                continue
+
+            draft_3g = Document.objects.filter(
+                datatracker_id=ref_3g.id
+            ).first() or get_or_create_draft_by_name(ref_3g.name, rpcapi=rpcapi)
+            if draft_3g is None:
+                logger.warning(
+                    "Could not get or create document for 3G reference %s (id=%d)",
+                    ref_3g.name,
+                    ref_3g.id,
+                )
+                continue
+
+            RpcRelatedDocument.objects.get_or_create(
+                source=source,
+                relationship=DocRelationshipName.NOT_RECEIVED_3G_RELATIONSHIP_SLUG,
+                target_document=draft_3g,
+            )
+            existing_target_dt_ids.add(ref_3g.id)
+
+
+@shared_task
+def compute_deep_references_task(related_doc_id: int):
+    """Celery task to asynchronously compute 2G and 3G not-received references."""
+    try:
+        _compute_deep_references(related_doc_id)
+    except Exception as e:
+        logger.error(
+            "Error computing deep references for RpcRelatedDocument %d: %s",
+            related_doc_id,
+            str(e),
+        )

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -1,6 +1,7 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
 
 import json
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -73,6 +74,7 @@ class UtilsTests(TestCase):
         # self.assertEqual(next_rfc_number(5), [7, 8, 9, 10, 11])
 
 
+@patch("rpc.serializers.compute_deep_references_task")
 class RelatedDocumentClusterSyncTests(TestCase):
     def setUp(self):
         self.relationship, _ = DocRelationshipName.objects.get_or_create(
@@ -89,7 +91,9 @@ class RelatedDocumentClusterSyncTests(TestCase):
         )
         self.client.force_login(self.user)
 
-    def test_create_related_document_creates_new_cluster_for_source_and_target(self):
+    def test_create_related_document_creates_new_cluster_for_source_and_target(
+        self, mock_task
+    ):
         ClusterFactory(number=7)
         source = RfcToBeFactory(draft__name="draft-source-doc")
         target = RfcToBeFactory(draft__name="draft-target-doc")
@@ -117,7 +121,9 @@ class RelatedDocumentClusterSyncTests(TestCase):
         self.assertEqual(source.cluster.number, 8)  # expect incremented cluster number
         self.assertEqual(target.cluster.number, source.cluster.number)
 
-    def test_create_related_document_adds_target_to_existing_source_cluster(self):
+    def test_create_related_document_adds_target_to_existing_source_cluster(
+        self, mock_task
+    ):
         source = RfcToBeFactory(draft__name="draft-source-doc")
         target = RfcToBeFactory(draft__name="draft-target-doc")
         cluster = ClusterFactory(number=11)


### PR DESCRIPTION
whenever a draft is added (on import or via the "Publishing dependencies" dialog), we also wanna process all `deep` references of that new draft and add the 2G/3G references

Logic implemented:
- trigger task `compute_deep_references_task` to **re-compute** whenever a Normref gets added or removed for any doc
- for delete: 
1. re-compute refs for all remaining 1Gs. If non exist, remove all 2G/3G refs directly

- for adding: 

1. delete all 2G/3G of the source
2. re-compute all current 1G
- for import:
1. if "not-received" references exist, change them to "refqueue"
2. if "not-received-2/3G" references exist, delete them
3. for the 2G relations, trigger a re-compute
