### PR TITLE
feat: only update RFC index on changes

### DIFF
--- a/rpc/admin.py
+++ b/rpc/admin.py
@@ -11,6 +11,7 @@ from .models import (
     Capability,
     Cluster,
     ClusterMember,
+    DirtyBits,
     DispositionName,
     DocRelationshipName,
     DumpInfo,
@@ -222,3 +223,8 @@ class TaskRunAdmin(admin.ModelAdmin):
 class PublicationAttemptAdmin(admin.ModelAdmin):
     list_display = ["rfc_to_be", "status", "started_at", "detail"]
     raw_id_fields = ["rfc_to_be"]
+
+
+@admin.register(DirtyBits)
+class DirtyBitsAdmin(admin.ModelAdmin):
+    list_display = ["slug", "dirty_time", "processed_time"]

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -1124,8 +1124,8 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
             raise APIException(
                 f"Failed to sync metadata with datatracker: {err}"
             ) from err
-        else:
-            mark_rfcindex_as_dirty()
+
+        mark_rfcindex_as_dirty()
         return Response()
 
     @extend_schema(

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -83,6 +83,7 @@ from .models import (
     UnusableRfcNumber,
 )
 from .pagination import DefaultLimitOffsetPagination
+from .rfcindex import mark_rfcindex_as_dirty
 from .serializers import (
     ActionHolderSerializer,
     AdditionalEmailSerializer,
@@ -1123,7 +1124,8 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
             raise APIException(
                 f"Failed to sync metadata with datatracker: {err}"
             ) from err
-
+        else:
+            mark_rfcindex_as_dirty()
         return Response()
 
     @extend_schema(
@@ -1543,6 +1545,14 @@ class UnusableRfcNumberViewSet(viewsets.ModelViewSet):
             )
 
         return super().partial_update(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        mark_rfcindex_as_dirty()
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        mark_rfcindex_as_dirty()
 
 
 @extend_schema(

--- a/rpc/lifecycle/publication.py
+++ b/rpc/lifecycle/publication.py
@@ -26,6 +26,7 @@ from rpc.models import PublicationAttempt, RfcToBe
 from rpcauth.models import User
 
 from .repo import GithubRepository, RepositoryError, TemporaryRepositoryError
+from ..rfcindex import mark_rfcindex_as_dirty
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +389,8 @@ def publish_rfctobe(
                 f"was published, but uploading its files failed. Manual correction "
                 f"is required."
             ) from err
-
+        else:
+            mark_rfcindex_as_dirty()
 
 class PublicationError(Exception):
     """Base class for publication exceptions"""

--- a/rpc/lifecycle/publication.py
+++ b/rpc/lifecycle/publication.py
@@ -25,8 +25,8 @@ from datatracker.utils.publication import publish_rfc_metadata, upload_rfc_conte
 from rpc.models import PublicationAttempt, RfcToBe
 from rpcauth.models import User
 
-from .repo import GithubRepository, RepositoryError, TemporaryRepositoryError
 from ..rfcindex import mark_rfcindex_as_dirty
+from .repo import GithubRepository, RepositoryError, TemporaryRepositoryError
 
 logger = logging.getLogger(__name__)
 
@@ -391,6 +391,7 @@ def publish_rfctobe(
             ) from err
         else:
             mark_rfcindex_as_dirty()
+
 
 class PublicationError(Exception):
     """Base class for publication exceptions"""

--- a/rpc/migrations/0020_dirtybits.py
+++ b/rpc/migrations/0020_dirtybits.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                 (
                     "slug",
                     models.CharField(
-                        choices=[("rfcindex", "RFC Index")], max_length=40
+                        choices=[("rfcindex", "RFC Index")], max_length=40, unique=True
                     ),
                 ),
                 ("dirty_time", models.DateTimeField(blank=True, null=True)),

--- a/rpc/migrations/0020_dirtybits.py
+++ b/rpc/migrations/0020_dirtybits.py
@@ -1,0 +1,35 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rpc", "0019_add_stream_manager_fk"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DirtyBits",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "slug",
+                    models.CharField(
+                        choices=[("rfcindex", "RFC Index")], max_length=40
+                    ),
+                ),
+                ("dirty_time", models.DateTimeField(blank=True, null=True)),
+                ("processed_time", models.DateTimeField(blank=True, null=True)),
+            ],
+            options={"verbose_name_plural": "dirty bits"},
+        ),
+    ]

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1354,7 +1354,7 @@ class DirtyBits(models.Model):
     class Slugs(models.TextChoices):
         RFCINDEX = "rfcindex", "RFC Index"
 
-    slug = models.CharField(max_length=40, blank=False, choices=Slugs)
+    slug = models.CharField(max_length=40, blank=False, choices=Slugs, unique=True)
     dirty_time = models.DateTimeField(null=True, blank=True)
     processed_time = models.DateTimeField(null=True, blank=True)
 

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1341,3 +1341,22 @@ class PublicationAttempt(models.Model):
         help_text="Record of an RFC publication request",
     )
     detail = models.CharField(max_length=1000, blank=True)
+
+
+class DirtyBits(models.Model):
+    """A weak semaphore mechanism for coordination with celery beat tasks
+
+    Web workers will set the "dirty_time" value for a given dirtybit slug.
+    Celery workers will do work if "processed_time" < "dirty_time" and update
+    "processed_time".
+    """
+
+    class Slugs(models.TextChoices):
+        RFCINDEX = "rfcindex", "RFC Index"
+
+    slug = models.CharField(max_length=40, blank=False, choices=Slugs)
+    dirty_time = models.DateTimeField(null=True, blank=True)
+    processed_time = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name_plural = "dirty bits"

--- a/rpc/rfcindex.py
+++ b/rpc/rfcindex.py
@@ -1,16 +1,20 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+import datetime
 import json
+import logging
 from io import StringIO
 from pathlib import Path
 
 import rpcapi_client
 from django.conf import settings
 from django.core.files.storage import storages
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from datatracker.rpcapi import with_rpcapi
-from rpc.models import RfcToBe, UnusableRfcNumber, DirtyBits
+from rpc.models import DirtyBits, RfcToBe, UnusableRfcNumber
+
+logger = logging.getLogger(__name__)
 
 
 def generate_unusable_rfc_numbers_json():
@@ -71,8 +75,52 @@ def refresh_rfc_index(*, rpcapi: rpcapi_client.PurpleApi):
     rpcapi.refresh_rfc_index()
 
 
+## DirtyBits management for the RFC index
+
+RFCINDEX_SLUG = DirtyBits.Slugs.RFCINDEX
+
+
 def mark_rfcindex_as_dirty():
-    DirtyBits.objects.update_or_create(
-        slug=DirtyBits.Slugs.RFCINDEX,
-        defaults={"dirty_time": timezone.now()},
+    _, created = DirtyBits.objects.update_or_create(
+        slug=RFCINDEX_SLUG, defaults={"dirty_time": timezone.now()}
+    )
+    if created:
+        logger.debug("Created DirtyBits(slug='%(slug)s')", {"slug": RFCINDEX_SLUG})
+
+
+def mark_rfcindex_as_processed(when: datetime.datetime):
+    n_updated = DirtyBits.objects.filter(
+        Q(processed_time__isnull=True) | Q(processed_time__lt=when),
+        slug=RFCINDEX_SLUG,
+    ).update(processed_time=when)
+    if n_updated > 0:
+        logger.debug(
+            "processed_time is now %(processed_time)s",
+            {"processed_time": when.isoformat()},
+        )
+    else:
+        logger.debug("processed_time not updated, no matching record found")
+
+
+def rfcindex_is_dirty():
+    """Does the rfc index need to be updated?"""
+    dirty_work, created = DirtyBits.objects.get_or_create(
+        slug=RFCINDEX_SLUG, defaults={"dirty_time": timezone.now()}
+    )
+    if created:
+        logger.debug("Created DirtyBits(slug='%(slug)s')", {"slug": RFCINDEX_SLUG})
+    logger.debug(
+        "DirtyBits(slug='%(slug)s'): dirty_time=%(dirty_time)s "
+        "processed_time=%(processed_time)s",
+        {
+            "slug": RFCINDEX_SLUG,
+            "dirty_time": dirty_work.dirty_time.isoformat(),
+            "processed_time": dirty_work.processed_time.isoformat()
+            if dirty_work.processed_time is not None
+            else "never",
+        },
+    )
+    return (
+        dirty_work.processed_time is None
+        or dirty_work.dirty_time >= dirty_work.processed_time
     )

--- a/rpc/rfcindex.py
+++ b/rpc/rfcindex.py
@@ -7,9 +7,10 @@ import rpcapi_client
 from django.conf import settings
 from django.core.files.storage import storages
 from django.db.models import QuerySet
+from django.utils import timezone
 
 from datatracker.rpcapi import with_rpcapi
-from rpc.models import RfcToBe, UnusableRfcNumber
+from rpc.models import RfcToBe, UnusableRfcNumber, DirtyBits
 
 
 def generate_unusable_rfc_numbers_json():
@@ -68,3 +69,10 @@ def refresh_rfc_index(*, rpcapi: rpcapi_client.PurpleApi):
     """
     create_rfc_index_support_blobs()
     rpcapi.refresh_rfc_index()
+
+
+def mark_rfcindex_as_dirty():
+    DirtyBits.objects.update_or_create(
+        slug=DirtyBits.Slugs.RFCINDEX,
+        defaults={"dirty_time": timezone.now()},
+    )

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -1,7 +1,7 @@
 # Copyright The IETF Trust 2025-2026, All Rights Reserved
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.db.models import F, Q
+from django.db.models import F
 from django.utils import timezone
 
 from rpc.lifecycle.blocked_assignments import apply_blocked_assignment_for_rfc
@@ -15,8 +15,8 @@ from .lifecycle.publication import (
     publish_rfctobe,
 )
 from .lifecycle.repo import GithubRepository
-from .models import MailMessage, MetadataValidationResults, RfcToBe, DirtyBits
-from .rfcindex import refresh_rfc_index
+from .models import MailMessage, MetadataValidationResults, RfcToBe
+from .rfcindex import mark_rfcindex_as_processed, refresh_rfc_index, rfcindex_is_dirty
 
 
 @shared_task
@@ -184,38 +184,14 @@ def process_rfctobe_changes_for_queue_task():
 
 @shared_task
 def refresh_rfc_index_task():
-    rfcindex_slug = DirtyBits.Slugs.RFCINDEX
-    dirty_work, created = DirtyBits.objects.get_or_create(
-        slug=rfcindex_slug, defaults={"dirty_time": timezone.now()}
-    )
-    if created:
-        logger.debug("Created DirtyBits(slug='%(slug)s')", {"slug": rfcindex_slug})
-    logger.debug(
-        "DirtyBits(slug='%(slug)s'): dirty_time=%(dirty_time)s "
-        "processed_time=%(processed_time)s",
-        {
-            "slug": rfcindex_slug,
-            "dirty_time": dirty_work.dirty_time.isoformat(),
-            "processed_time": dirty_work.processed_time.isoformat() if dirty_work.processed_time is not None else "never",
-        }
-    )
-    if (
-        dirty_work.processed_time is None
-        or dirty_work.dirty_time >= dirty_work.processed_time
-    ):
+    if rfcindex_is_dirty():
         logger.info("RFC index data has updates, refreshing")
         new_processed_time = timezone.now()
         refresh_rfc_index()
-        DirtyBits.objects.filter(
-            Q(processed_time__isnull=True) | Q(processed_time__lt=new_processed_time),
-            slug=rfcindex_slug,
-        ).update(processed_time=new_processed_time)
-        logger.debug(
-            "processed_time is now %(processed_time)s",
-            {"processed_time": new_processed_time.isoformat()},
-        )
+        mark_rfcindex_as_processed(new_processed_time)
     else:
         logger.debug("RFC index not updated, skipping")
+
 
 @shared_task
 def update_blocked_assignments_for_in_progress_rfcs_task():

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -1,7 +1,8 @@
 # Copyright The IETF Trust 2025-2026, All Rights Reserved
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.db.models import F
+from django.db.models import F, Q
+from django.utils import timezone
 
 from rpc.lifecycle.blocked_assignments import apply_blocked_assignment_for_rfc
 from utils.task_utils import RetryTask
@@ -14,7 +15,7 @@ from .lifecycle.publication import (
     publish_rfctobe,
 )
 from .lifecycle.repo import GithubRepository
-from .models import MailMessage, MetadataValidationResults, RfcToBe
+from .models import MailMessage, MetadataValidationResults, RfcToBe, DirtyBits
 from .rfcindex import refresh_rfc_index
 
 
@@ -183,8 +184,38 @@ def process_rfctobe_changes_for_queue_task():
 
 @shared_task
 def refresh_rfc_index_task():
-    refresh_rfc_index()
-
+    rfcindex_slug = DirtyBits.Slugs.RFCINDEX
+    dirty_work, created = DirtyBits.objects.get_or_create(
+        slug=rfcindex_slug, defaults={"dirty_time": timezone.now()}
+    )
+    if created:
+        logger.debug("Created DirtyBits(slug='%(slug)s')", {"slug": rfcindex_slug})
+    logger.debug(
+        "DirtyBits(slug='%(slug)s'): dirty_time=%(dirty_time)s "
+        "processed_time=%(processed_time)s",
+        {
+            "slug": rfcindex_slug,
+            "dirty_time": dirty_work.dirty_time.isoformat(),
+            "processed_time": dirty_work.processed_time.isoformat() if dirty_work.processed_time is not None else "never",
+        }
+    )
+    if (
+        dirty_work.processed_time is None
+        or dirty_work.dirty_time >= dirty_work.processed_time
+    ):
+        logger.info("RFC index data has updates, refreshing")
+        new_processed_time = timezone.now()
+        refresh_rfc_index()
+        DirtyBits.objects.filter(
+            Q(processed_time__isnull=True) | Q(processed_time__lt=new_processed_time),
+            slug=rfcindex_slug,
+        ).update(processed_time=new_processed_time)
+        logger.debug(
+            "processed_time is now %(processed_time)s",
+            {"processed_time": new_processed_time.isoformat()},
+        )
+    else:
+        logger.debug("RFC index not updated, skipping")
 
 @shared_task
 def update_blocked_assignments_for_in_progress_rfcs_task():


### PR DESCRIPTION
Adds the `DirtyBits` model as used in the errata app. Updates the `refresh_rfc_index_task()` to check whether the index is dirty before taking action. Marks the index as dirty when a new RFC is published, metadata changes to a published RFC are synced to datatracker, or changes are made to the unpublishable RFC set.

When deployed, we should schedule the task to run every 5-10 minutes.