### PR TITLE
fix: not-received drafts shall not be added to a cluster

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -558,7 +558,6 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                             },
                         )
                     create_rpc_related_document("not-received", rfctobe.pk, draft.name)
-                    reference_docs.append(draft)
                 else:
                     disposition = existing_rfc_to_be[reference.id]
                     if disposition in ("created", "in_progress"):


### PR DESCRIPTION
don't create a ClusterMember for Normrefs that are not received