### PR TITLE
fix: put imported draft in cluster of withdrawn

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -590,6 +590,9 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                         create_rpc_related_document(
                             "withdrawnref", rfctobe.pk, reference.name
                         )
+                        received_reference_ids.add(reference.id)
+                    elif disposition == "published":
+                        received_reference_ids.add(reference.id)
                     else:
                         pass  # ignoring references to already published RfcToBe
 


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/1066

on import, a draft should go into same cluster as Normrefs that are 
a) withdrawn or 
b) already published in the meantime