### PR TITLE
fix: cluster reordering

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -946,7 +946,7 @@ class ClusterViewSet(
             # Null out order for inactive members (published/withdrawn) so they don't
             # collide with the sequential order values assigned to active members.
             ClusterMember.objects.filter(cluster=cluster).exclude(
-                doc__rfctobe__disposition__slug__in=["created", "in_progress"]
+                doc__rfctobe__disposition__slug__in=DispositionName.ACTIVE_SLUGS
             ).update(order=None)
 
             for idx, draft_name in enumerate(draft_names, start=1):
@@ -955,7 +955,11 @@ class ClusterViewSet(
                     doc.order = idx
                     doc.save()
 
-        cluster = Cluster.objects.with_data_annotated().with_is_active_annotated().get(pk=cluster.pk)
+        cluster = (
+            Cluster.objects.with_data_annotated()
+            .with_is_active_annotated()
+            .get(pk=cluster.pk)
+        )
 
         response_serializer = ClusterSerializer(cluster)
         return Response(response_serializer.data)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -914,8 +914,13 @@ class ClusterViewSet(
         serializer.is_valid(raise_exception=True)
         draft_names = serializer.validated_data["draft_names"]
 
-        # Get all documents currently in the cluster
-        cluster_docs = list(ClusterMember.objects.filter(cluster=cluster))
+        # Get all active documents currently in the cluster
+        cluster_docs = list(
+            ClusterMember.objects.filter(
+                cluster=cluster,
+                doc__rfctobe__disposition__slug__in=DispositionName.ACTIVE_SLUGS,
+            ).select_related("doc")
+        )
 
         # Validate that the provided draft names match cluster documents
         cluster_draft_names = {cluster_doc.doc.name for cluster_doc in cluster_docs}
@@ -938,12 +943,19 @@ class ClusterViewSet(
 
         # Update cluster_order for each document
         with transaction.atomic():
+            # Null out order for inactive members (published/withdrawn) so they don't
+            # collide with the sequential order values assigned to active members.
+            ClusterMember.objects.filter(cluster=cluster).exclude(
+                doc__rfctobe__disposition__slug__in=["created", "in_progress"]
+            ).update(order=None)
+
             for idx, draft_name in enumerate(draft_names, start=1):
                 doc = doc_map[draft_name]
-                doc.order = idx
-                doc.save()
+                if doc.order != idx:
+                    doc.order = idx
+                    doc.save()
 
-        cluster.refresh_from_db()
+        cluster = Cluster.objects.with_data_annotated().with_is_active_annotated().get(pk=cluster.pk)
 
         response_serializer = ClusterSerializer(cluster)
         return Response(response_serializer.data)

--- a/rpc/migrations/0020_clustermember_order_nullable.py
+++ b/rpc/migrations/0020_clustermember_order_nullable.py
@@ -1,0 +1,22 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rpc", "0019_add_stream_manager_fk"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="clustermember",
+            name="order",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name="historicalclustermember",
+            name="order",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+    ]

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -494,6 +494,7 @@ class DispositionName(Name):
     PUBLISHED = "published"
     WITHDRAWN = "withdrawn"
     SLUGS = [CREATED, IN_PROGRESS, PUBLISHED, WITHDRAWN]
+    ACTIVE_SLUGS = [CREATED, IN_PROGRESS]
 
 
 class SourceFormatName(Name):
@@ -604,8 +605,21 @@ class DocRelationshipName(Name):
 class ClusterMember(models.Model):
     cluster = models.ForeignKey("rpc.Cluster", on_delete=models.CASCADE)
     doc = models.ForeignKey("datatracker.Document", on_delete=models.CASCADE)
-    order = models.IntegerField(null=False, blank=False)
+    order = models.IntegerField(null=True, blank=True)
     history = HistoricalRecords()
+
+    def clean(self):
+        from django.core.exceptions import ValidationError
+
+        if self.order is None and self.doc_id is not None:
+            rfctobe = RfcToBe.objects.filter(
+                draft_id=self.doc_id,
+                disposition__slug__in=DispositionName.ACTIVE_SLUGS,
+            ).first()
+            if rfctobe is not None:
+                raise ValidationError(
+                    {"order": "order must not be null for active cluster members"}
+                )
 
     class Meta:
         constraints = [


### PR DESCRIPTION
currently reordering fails for many clusters that contain PUBLISHED rfcs.

the published ones are filtered out by the API, they can be ignored for reordering, but they still require to have an order number since that field is NOT nullable.

Solution: make field "order" for ClusterMembers nullable, with a guard that will require it to be set for "active" drafts (created/in_progress)
When storing new order, set all INACTIVE draft's order to NULL. then only update the order field if it actually changed.

