### PR TITLE
feat: add API and UI for ClusterMember history

### DIFF
--- a/client/app/components/ClusterMembershipHistory.vue
+++ b/client/app/components/ClusterMembershipHistory.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <h2 class="text-lg font-semibold mb-3">Cluster-Members History</h2>
+    <div v-if="status === 'pending'" class="text-sm text-gray-500">Loading history...</div>
+    <div v-else-if="status === 'error'" class="text-sm text-red-500">Failed to load history.</div>
+    <div v-else-if="!entries.length" class="text-sm text-gray-500">No history recorded.</div>
+    <table v-else class="w-full text-sm border-collapse">
+      <thead>
+        <tr class="border-b border-gray-300 dark:border-gray-600 text-left text-xs uppercase text-gray-500 dark:text-gray-400">
+          <th class="py-2 pr-4 font-medium">Time</th>
+          <th class="py-2 pr-4 font-medium">Document</th>
+          <th class="py-2 pr-4 font-medium">Change</th>
+          <th class="py-2 font-medium">By</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="entry in entries" :key="`${entry.time}-${entry.draftName}-${entry.type}`"
+          class="border-b border-gray-100 dark:border-gray-800">
+          <td class="py-2 pr-4 text-gray-600 dark:text-gray-400 whitespace-nowrap">
+            {{ entry.time ? new Date(entry.time).toLocaleString() : '—' }}
+          </td>
+          <td class="py-2 pr-4 font-mono">{{ entry.draftName ?? '—' }}</td>
+          <td class="py-2 pr-4">
+            <span :class="{
+              'text-green-600 dark:text-green-400': entry.type === 'added',
+              'text-red-600 dark:text-red-400': entry.type === 'removed',
+              'text-blue-600 dark:text-blue-400': entry.type === 'reordered',
+            }">{{ entry.type ?? '—' }}</span>
+          </td>
+          <td class="py-2">{{ (entry.by as any)?.name ?? entry.by ?? '—' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ClusterMemberHistory } from '~/purple_client'
+
+type Props = {
+  clusterNumber: number
+}
+
+const props = defineProps<Props>()
+
+const api = useApi()
+
+const { data, status } = useAsyncData(
+  () => `cluster-history-${props.clusterNumber}`,
+  () => api.clustersHistoryList({ number: props.clusterNumber, limit: 200 }),
+  { server: false, lazy: true }
+)
+
+const entries = computed<ClusterMemberHistory[]>(() => data.value?.results ?? [])
+</script>

--- a/client/app/components/ClusterReorder.vue
+++ b/client/app/components/ClusterReorder.vue
@@ -1,7 +1,7 @@
 <template>
   <BaseCard>
     <template #header>
-      <CardHeader :title="`Reorder Cluster ${props.cluster.number}`">
+      <CardHeader :title="`Cluster-Members C${props.cluster.number}`">
         <template #actions>
           <Icon v-if="queueStatus === 'pending' || labelsStatus === 'pending'" name="ei:spinner-3" size="1.3rem" class="animate-spin" title="Loading additional information about cluster documents" />
           <span v-else-if="queueStatus === 'error' || labelsStatus === 'error'" class="text-red-800 dark:text-red-400">

--- a/client/app/pages/clusters/[number].vue
+++ b/client/app/pages/clusters/[number].vue
@@ -22,6 +22,8 @@
     <div v-else>No filtered cluster</div>
 
     <ClusterReorder v-if="filteredCluster" :cluster="filteredCluster" :on-success="refresh" class="max-w-[800px]" :rfcs-to-be="rfcsToBe" />
+
+    <ClusterMembershipHistory v-if="clusterNumber" :cluster-number="clusterNumber" class="mt-8 max-w-[800px]" />
   </div>
   <div v-else>
     Unknown cluster

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -401,6 +401,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/Cluster'
           description: ''
+  /api/rpc/clusters/{number}/history/:
+    get:
+      operationId: clusters_history_list
+      description: List the add/remove/reorder history for a cluster's membership
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: path
+        name: number
+        schema:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        required: true
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - purple
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedClusterMemberHistoryList'
+          description: ''
   /api/rpc/clusters/{number}/order/:
     post:
       operationId: clusters_reorder_documents
@@ -3558,6 +3593,25 @@ components:
       required:
       - name
       - order
+    ClusterMemberHistory:
+      type: object
+      description: Serialize a HistoricalClusterMember record as a membership change
+        event
+      properties:
+        time:
+          type: string
+          format: date-time
+          readOnly: true
+        by:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        draft_name:
+          type: string
+          nullable: true
+          readOnly: true
     ClusterMemberRequest:
       type: object
       properties:
@@ -4404,6 +4458,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BaseDatatrackerPerson'
+    PaginatedClusterMemberHistoryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterMemberHistory'
     PaginatedDocumentCommentList:
       type: object
       required:

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -951,11 +951,19 @@ class ClusterViewSet(
         return Response(response_serializer.data)
 
     @extend_schema(responses=ClusterMemberHistorySerializer(many=True))
-    @action(detail=True, methods=["get"], url_path="history", pagination_class=DefaultLimitOffsetPagination, filter_backends=[])
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="history",
+        pagination_class=DefaultLimitOffsetPagination,
+        filter_backends=[],
+    )
     def history(self, request, number=None):
         """List the add/remove/reorder history for a cluster's membership"""
         cluster = self.get_object()
-        qs = ClusterMember.history.filter(cluster_id=cluster.pk).order_by("-history_date")
+        qs = ClusterMember.history.filter(cluster_id=cluster.pk).order_by(
+            "-history_date"
+        )
         page = self.paginate_queryset(qs)
         if page is not None:
             serializer = ClusterMemberHistorySerializer(page, many=True)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -92,6 +92,7 @@ from .serializers import (
     BaseDatatrackerPersonSerializer,
     CapabilitySerializer,
     ClusterAddRemoveDocumentSerializer,
+    ClusterMemberHistorySerializer,
     ClusterReorderDocumentsSerializer,
     ClusterSerializer,
     CreateActionHolderSerializer,
@@ -940,13 +941,27 @@ class ClusterViewSet(
         with transaction.atomic():
             for idx, draft_name in enumerate(draft_names, start=1):
                 doc = doc_map[draft_name]
-                doc.order = idx
-                doc.save()
+                if doc.order != idx:
+                    doc.order = idx
+                    doc.save()
 
         cluster.refresh_from_db()
 
         response_serializer = ClusterSerializer(cluster)
         return Response(response_serializer.data)
+
+    @extend_schema(responses=ClusterMemberHistorySerializer(many=True))
+    @action(detail=True, methods=["get"], url_path="history", pagination_class=DefaultLimitOffsetPagination, filter_backends=[])
+    def history(self, request, number=None):
+        """List the add/remove/reorder history for a cluster's membership"""
+        cluster = self.get_object()
+        qs = ClusterMember.history.filter(cluster_id=cluster.pk).order_by("-history_date")
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = ClusterMemberHistorySerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = ClusterMemberHistorySerializer(qs, many=True)
+        return Response(serializer.data)
 
 
 class AssignmentViewSet(viewsets.ModelViewSet):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1358,6 +1358,33 @@ class ClusterSerializer(serializers.ModelSerializer):
         return instance
 
 
+class ClusterMemberHistorySerializer(serializers.Serializer):
+    """Serialize a HistoricalClusterMember record as a membership change event"""
+
+    time = serializers.DateTimeField(source="history_date", read_only=True)
+    by = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
+    draft_name = serializers.SerializerMethodField()
+
+    def get_by(self, obj):
+        if obj.history_user is None:
+            return None
+        dt_person = obj.history_user.datatracker_person()
+        if dt_person is None:
+            return None
+        return BaseDatatrackerPersonSerializer(dt_person).data
+
+    def get_type(self, obj) -> str:
+        return {"+": "added", "~": "reordered", "-": "removed"}.get(
+            obj.history_type, obj.history_type
+        )
+
+    def get_draft_name(self, obj) -> str | None:
+        try:
+            return Document.objects.get(pk=obj.doc_id).name
+        except Document.DoesNotExist:
+            return None
+
 @dataclass
 class SubmissionAuthor:
     id: int

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1385,6 +1385,7 @@ class ClusterMemberHistorySerializer(serializers.Serializer):
         except Document.DoesNotExist:
             return None
 
+
 @dataclass
 class SubmissionAuthor:
     id: int


### PR DESCRIPTION
resolves https://github.com/ietf-tools/purple/issues/984

- API endpoint for clustermember history
- add to API client schema
- display in UI a table with changes (add/remove/reorder)