### PR TITLE
chore: add trap call to init scripts

### DIFF
--- a/dev/build/backend-start.sh
+++ b/dev/build/backend-start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Bare call to trap seems to help TERM signals exit during sleep
+trap
+
 if ! ./manage.py migrate --check ; then
     echo "Unapplied migrations found, waiting to start..."
     sleep 5

--- a/dev/build/celery-start.sh
+++ b/dev/build/celery-start.sh
@@ -10,6 +10,9 @@
 CELERY=/usr/local/bin/celery
 MANAGE_PY=./manage.py
 
+# Bare call to trap seems to help TERM signals exit during sleep
+trap
+
 migrations_applied_for () {
     local DATABASE=${1:-default}
     $MANAGE_PY migrate --check --database "$DATABASE"

--- a/docker/scripts/celery-init.sh
+++ b/docker/scripts/celery-init.sh
@@ -12,20 +12,13 @@ pip3 --disable-pip-version-check --no-cache-dir install --user --no-warn-script-
 # specify celery location
 CELERY=/home/dev/.local/bin/celery
 
+# Bare call to trap seems to help TERM signals exit during sleep
+trap
+
 # Wait for DB container
 echo "Waiting for DB container to come online..."
 /usr/local/bin/wait-for db:5432 -- echo "PostgreSQL ready"
 
-# Prepare to run celery
-cleanup () {
-  # Cleanly terminate the celery app by sending it a TERM, then waiting for it to exit.
-  if [[ -n "${celery_pid}" ]]; then
-    echo "Gracefully terminating celery worker."
-    kill -TERM "${celery_pid}"
-    wait "${celery_pid}"
-  fi
-}
-trap 'trap "" TERM; cleanup' TERM
 echo "Starting celery worker with beat scheduler..."
 watchmedo auto-restart \
           --patterns '*.py' \

--- a/docker/scripts/celery-init.sh
+++ b/docker/scripts/celery-init.sh
@@ -19,6 +19,16 @@ trap
 echo "Waiting for DB container to come online..."
 /usr/local/bin/wait-for db:5432 -- echo "PostgreSQL ready"
 
+# Prepare to run celery
+cleanup () {
+  # Cleanly terminate the celery app by sending it a TERM, then waiting for it to exit.
+  if [[ -n "${celery_pid}" ]]; then
+    echo "Gracefully terminating celery worker."
+    kill -TERM "${celery_pid}"
+    wait "${celery_pid}"
+  fi
+}
+trap 'trap "" TERM; cleanup' TERM
 echo "Starting celery worker with beat scheduler..."
 watchmedo auto-restart \
           --patterns '*.py' \


### PR DESCRIPTION
According to man pages, this should just show the state of the signal handlers. In local testing with Docker, it seems to help the shell exit on TERM for some reason, and should be harmless.