### PR TITLE
fix: redo fetch metadata after fail, improve messages

### DIFF
--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -320,7 +320,7 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
     step.value = {
       type: 'error',
       errorText: `Unable to load RFC ${draftName.value}. Server error: ${rfcToBeError.value?.message ?? ''} ${metadataValidationResultsError.value ?? ''}`,
-      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) ? { headSha: precomputedResult.headSha ?? NO_HEAD_SHA_SENTINEL } : undefined,
+      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) ? { headSha: precomputedResult.headSha! } : undefined,
       showResyncButton: true
     }
     return
@@ -429,7 +429,7 @@ const fetchAndVerifyMetadata = async () => {
     step.value = {
       type: 'error',
       errorText: `Couldn't start/poll for metadata sync results. Error: ${error}`,
-      showDeleteAndRetryButton: resultsCreate ? { headSha: resultsCreate.headSha ?? NO_HEAD_SHA_SENTINEL } : undefined,
+      showDeleteAndRetryButton: resultsCreate ? { headSha: resultsCreate.headSha } : undefined,
       showResyncButton: true
     }
     if (!resultsCreate) {
@@ -454,22 +454,19 @@ const fetchAndVerifyMetadata = async () => {
   }
 }
 
-const NO_HEAD_SHA_SENTINEL = 'no_head_sha'
-
-const deleteMetadataValidationAndRetry = async (headSha: string | null | undefined) => {
-  const resolvedHeadSha = headSha ?? NO_HEAD_SHA_SENTINEL
+const deleteMetadataValidationAndRetry = async (headSha: string) => {
   step.value = { type: 'loading' }
   try {
     await api.metadataValidationResultsDelete({
       draftName: draftName.value,
-      headSha: resolvedHeadSha,
+      headSha,
     })
   } catch (error: unknown) {
     snackbarForErrors({ snackbar, error, defaultTitle: "Couldn't delete validation results" })
     step.value = {
       type: 'error',
       errorText: "Couldn't delete validation results",
-      showDeleteAndRetryButton: { headSha: resolvedHeadSha },
+      showDeleteAndRetryButton: { headSha },
       showResyncButton: true
     }
     return

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -11,7 +11,7 @@
         </div>
         <div class="text-center">
           <BaseButton btn-type="default"
-            @click="deleteMetadataValidationAndRetry()"
+            @click="deleteMetadataValidationAndRetry(step.headSha)"
             class="ml-2">
             Try again
           </BaseButton>
@@ -45,7 +45,7 @@
         </div>
         <div :class="step.showDeleteAndRetryButton ? 'flex justify-between' : 'text-center'">
           <BaseButton v-if="step.showDeleteAndRetryButton" btn-type="outline"
-            @click="deleteMetadataValidationAndRetry()">
+            @click="deleteMetadataValidationAndRetry(step.showDeleteAndRetryButton.headSha)">
             Retry metadata validation
           </BaseButton>
           <BaseButton v-if="step.showResyncButton" btn-type="default" @click="fetchAndVerifyMetadata" class="ml-2">
@@ -70,7 +70,7 @@
           </p>
           <div class="flex justify-center mt-8 pt-4 border-t border-gray-300 dark:border-gray-300">
             <BaseButton btn-type="default"
-              @click="() => step.type === 'diff' ? deleteMetadataValidationAndRetry() : undefined">
+              @click="() => step.type === 'diff' ? deleteMetadataValidationAndRetry(step.headSha) : undefined">
               Try again
             </BaseButton>
           </div>
@@ -140,7 +140,7 @@
             </div>
             <div>
               <BaseButton btn-type="secondary"
-                @click="deleteMetadataValidationAndRetry">
+                @click="deleteMetadataValidationAndRetry(step.headSha)">
                 Redo metadata validation
               </BaseButton>
             </div>
@@ -248,12 +248,12 @@ type Step =
   | { type: 'getMetadataValidationResults' }
   | { type: 'fetchAndVerifyAndMetadataButton' }
   | { type: 'loading' }
-  | { type: 'error', errorText: string, showResyncButton?: boolean, showDeleteAndRetryButton?: boolean }
+  | { type: 'error', errorText: string, showResyncButton?: boolean, showDeleteAndRetryButton?: { headSha: string } }
   | {
     type: 'diff'
     error?: string
   } & MetadataValidationResults
-  | { type: 'cancelled' }
+  | { type: 'cancelled', headSha?: string }
   | { type: 'databaseUpdated', error?: string }
   | { type: 'rfcPosted', error?: string }
   | { type: 'alreadyPublished' }
@@ -320,7 +320,7 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
     step.value = {
       type: 'error',
       errorText: `Unable to load RFC ${draftName.value}. Server error: ${rfcToBeError.value?.message ?? ''} ${metadataValidationResultsError.value ?? ''}`,
-      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) && !!precomputedResult?.headSha,
+      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) ? { headSha: precomputedResult.headSha ?? NO_HEAD_SHA_SENTINEL } : undefined,
       showResyncButton: true
     }
     return
@@ -429,7 +429,7 @@ const fetchAndVerifyMetadata = async () => {
     step.value = {
       type: 'error',
       errorText: `Couldn't start/poll for metadata sync results. Error: ${error}`,
-      showDeleteAndRetryButton: !!resultsCreate?.headSha,
+      showDeleteAndRetryButton: resultsCreate ? { headSha: resultsCreate.headSha ?? NO_HEAD_SHA_SENTINEL } : undefined,
       showResyncButton: true
     }
     if (!resultsCreate) {
@@ -454,18 +454,22 @@ const fetchAndVerifyMetadata = async () => {
   }
 }
 
-const deleteMetadataValidationAndRetry = async () => {
+const NO_HEAD_SHA_SENTINEL = 'no_head_sha'
+
+const deleteMetadataValidationAndRetry = async (headSha: string | null | undefined) => {
+  const resolvedHeadSha = headSha ?? NO_HEAD_SHA_SENTINEL
   step.value = { type: 'loading' }
   try {
-    await api.documentsMetadataValidationResultsDestroy({
-      draftName: draftName.value
+    await api.metadataValidationResultsDelete({
+      draftName: draftName.value,
+      headSha: resolvedHeadSha,
     })
   } catch (error: unknown) {
     snackbarForErrors({ snackbar, error, defaultTitle: "Couldn't delete validation results" })
     step.value = {
       type: 'error',
       errorText: "Couldn't delete validation results",
-      showDeleteAndRetryButton: true,
+      showDeleteAndRetryButton: { headSha: resolvedHeadSha },
       showResyncButton: true
     }
     return
@@ -542,7 +546,8 @@ const metadataValidationResultsSyncHandler = async () => {
 }
 
 const cancel = () => {
-  step.value = { type: 'cancelled' }
+  const headSha = step.value.type === 'diff' ? step.value.headSha ?? undefined : undefined
+  step.value = { type: 'cancelled', headSha }
 }
 
 const syncCurrentMetadata = async () => {

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -11,7 +11,7 @@
         </div>
         <div class="text-center">
           <BaseButton btn-type="default"
-            @click="deleteMetadataValidationAndRetry(step.headSha)"
+            @click="deleteMetadataValidationAndRetry(step.headSha!)"
             class="ml-2">
             Try again
           </BaseButton>
@@ -70,7 +70,7 @@
           </p>
           <div class="flex justify-center mt-8 pt-4 border-t border-gray-300 dark:border-gray-300">
             <BaseButton btn-type="default"
-              @click="() => step.type === 'diff' ? deleteMetadataValidationAndRetry(step.headSha) : undefined">
+              @click="() => step.type === 'diff' ? deleteMetadataValidationAndRetry(step.headSha!) : undefined">
               Try again
             </BaseButton>
           </div>
@@ -140,7 +140,7 @@
             </div>
             <div>
               <BaseButton btn-type="secondary"
-                @click="deleteMetadataValidationAndRetry(step.headSha)">
+                @click="deleteMetadataValidationAndRetry(step.headSha!)">
                 Redo metadata validation
               </BaseButton>
             </div>
@@ -429,7 +429,7 @@ const fetchAndVerifyMetadata = async () => {
     step.value = {
       type: 'error',
       errorText: `Couldn't start/poll for metadata sync results. Error: ${error}`,
-      showDeleteAndRetryButton: resultsCreate ? { headSha: resultsCreate.headSha } : undefined,
+      showDeleteAndRetryButton: resultsCreate ? { headSha: resultsCreate.headSha! } : undefined,
       showResyncButton: true
     }
     if (!resultsCreate) {

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -10,7 +10,9 @@
           Cancelled
         </div>
         <div class="text-center">
-          <BaseButton btn-type="default" @click="fetchAndVerifyMetadata" class="ml-2">
+          <BaseButton btn-type="default"
+            @click="deleteMetadataValidationAndRetry()"
+            class="ml-2">
             Try again
           </BaseButton>
         </div>
@@ -43,7 +45,7 @@
         </div>
         <div :class="step.showDeleteAndRetryButton ? 'flex justify-between' : 'text-center'">
           <BaseButton v-if="step.showDeleteAndRetryButton" btn-type="outline"
-            @click="deleteMetadataValidationAndRetry(step.showDeleteAndRetryButton.headSha)">
+            @click="deleteMetadataValidationAndRetry()">
             Retry metadata validation
           </BaseButton>
           <BaseButton v-if="step.showResyncButton" btn-type="default" @click="fetchAndVerifyMetadata" class="ml-2">
@@ -52,75 +54,84 @@
         </div>
       </template>
       <template v-else-if="step.type === 'diff'">
-        <Heading :heading-level="2"
+        <Heading v-if="step.status !== 'failed'" :heading-level="2"
           :class="['px-8 py-4', step.status === 'success' ? 'text-gray-700 dark:text-gray-300' : 'text-red-800 dark:text-red-300']">
           <span v-if="step.status === 'success'" class="font-bold">Metadata validation completed</span>
           <template v-else>
-            <span class="font-bold mr-1">Metadata validation failed:</span>
-            {{ step.status ?? '(unknown status)' }}
+            <span class="font-bold">Metadata validation failed</span>
           </template>
         </Heading>
-        <p v-if="step.isError" class="ml-8 mb-4 text-red-800 dark:text-red-300 font-bold">Validation error</p>
-        <p class="ml-8 mb-4 text-sm text-sm text-black dark:text-white">
-          Metadata
-          {{ SPACE }}
-          <span v-if="!step.isMatch" class="text-red-800 dark:text-red-300">does not match</span>
-          {{ SPACE }}
-          <span v-if="step.isMatch" class="text-green-800 dark:text-green-300">matches</span>
-          {{ SPACE }}
-          <span v-if="!step.isError">
-            but it can be published.
-          </span>
-          {{ SPACE }}
-          <span v-if="step.isError">
-            and it <span class="font-bold">cannot be published</span>.
-          </span>
-        </p>
-        <p v-if="step.headSha" class="ml-8 mb-4 text-sm text-black dark:text-white">
-          Fetched git commit
-          {{ SPACE }}
-          <button
-            class="inline-block rounded-md w-[9em] bg-gray-200 hover:bg-gray-300 focus:bg-gray-300 dark:bg-gray-700 dark:focus:bg-gray-600 dark:hover:bg-gray-600 font-mono p-0.5 truncate"
-            @click="() => step.type === 'diff' && step.headSha ? copyGitHashToClipboard(step.headSha) : undefined">
-            <Icon name="uil:clipboard-notes" size="1rem" class="align-middle mx-0.5" /><code>{{ step.headSha }}</code>
-          </button>
-          {{ SPACE }}
-          from
-          {{ SPACE }}
-          <a :href="step.repository ? gitHubUrlBuilder(step.repository) : undefined" :class="ANCHOR_STYLE">{{
-            step.repository
-          }}</a>
-          {{ SPACE }}
-          <TooltipProvider v-if="step.receivedAt">
-            <TooltipRoot>
-              <TooltipTrigger>
-                <time :datetime="DateTime.fromJSDate(step.receivedAt).toISOTime() ?? undefined">
-                  {{ DateTime.fromJSDate(step.receivedAt).toRelative() }}
-                </time>
-              </TooltipTrigger>
-              <TooltipPortal>
-                <TooltipContent class="shadow-md bg-white text-black dark:bg-black dark:text-white rounded px-2 py-1">
-                  {{ DateTime.fromJSDate(step.receivedAt).toISO()?.replace(/T/gi, ' ') }}
-                </TooltipContent>
-              </TooltipPortal>
-            </TooltipRoot>
-          </TooltipProvider>
-        </p>
-        <p v-else class="ml-8 mb-4 text-sm text-black dark:text-white">
-          No git commit available in API response. Can't publish until this is verified.
-        </p>
-        <p v-if="step.detail && step.detail.length > 0"
-          class="bg-yellow-200 text-yellow-900 dark:bg-yellow-700 text-sm dark:text-white p-2 mx-6 my-2">
-          <Icon name="uil:info-circle" size="1rem" class="mr-2" />
-          {{ step.detail }}
-        </p>
-        <BaseCard>
-          <div class="w-full">
-            <DiffTable v-if="step.metadataCompare" :columns="diffColumns" :rows="step.metadataCompare" />
-            <p v-else class="text-center">(no diff available)</p>
+        <template v-if="step.status === 'failed'">
+          <!-- Simplified failure view: just the error message and a retry button -->
+          <p v-if="step.detail && step.detail.length > 0"
+            class="bg-yellow-200 text-yellow-900 dark:bg-yellow-700 text-sm dark:text-white p-2 mx-6 my-2">
+            <Icon name="uil:info-circle" size="1rem" class="mr-2" />
+            {{ step.detail }}
+          </p>
+          <div class="flex justify-center mt-8 pt-4 border-t border-gray-300 dark:border-gray-300">
+            <BaseButton btn-type="default"
+              @click="() => step.type === 'diff' ? deleteMetadataValidationAndRetry() : undefined">
+              Try again
+            </BaseButton>
           </div>
-        </BaseCard>
-        <template v-if="step.status === 'success'">
+        </template>
+        <template v-else>
+          <!-- Full success/mismatch view -->
+          <p v-if="step.isError" class="ml-8 mb-4 text-red-800 dark:text-red-300 font-bold">Validation error</p>
+          <p v-if="step.metadataCompare" class="ml-8 mb-4 text-sm text-sm text-black dark:text-white">
+            Metadata
+            {{ SPACE }}
+            <span v-if="!step.isMatch" class="text-red-800 dark:text-red-300">does not match</span>
+            {{ SPACE }}
+            <span v-if="step.isMatch" class="text-green-800 dark:text-green-300">matches</span>
+            {{ SPACE }}
+            <span v-if="!step.isError">
+              but it can be published.
+            </span>
+            {{ SPACE }}
+            <span v-if="step.isError">
+              and it <span class="font-bold">cannot be published</span>.
+            </span>
+          </p>
+          <p v-if="step.headSha" class="ml-8 mb-4 text-sm text-black dark:text-white">
+            Fetched git commit
+            {{ SPACE }}
+            <button
+              class="inline-block rounded-md w-[9em] bg-gray-200 hover:bg-gray-300 focus:bg-gray-300 dark:bg-gray-700 dark:focus:bg-gray-600 dark:hover:bg-gray-600 font-mono p-0.5 truncate"
+              @click="() => step.type === 'diff' && step.headSha ? copyGitHashToClipboard(step.headSha) : undefined">
+              <Icon name="uil:clipboard-notes" size="1rem" class="align-middle mx-0.5" /><code>{{ step.headSha }}</code>
+            </button>
+            {{ SPACE }}
+            from
+            {{ SPACE }}
+            <a :href="step.repository ? gitHubUrlBuilder(step.repository) : undefined" :class="ANCHOR_STYLE">{{
+              step.repository
+            }}</a>
+            {{ SPACE }}
+            <TooltipProvider v-if="step.receivedAt">
+              <TooltipRoot>
+                <TooltipTrigger>
+                  <time :datetime="DateTime.fromJSDate(step.receivedAt).toISOTime() ?? undefined">
+                    {{ DateTime.fromJSDate(step.receivedAt).toRelative() }}
+                  </time>
+                </TooltipTrigger>
+                <TooltipPortal>
+                  <TooltipContent class="shadow-md bg-white text-black dark:bg-black dark:text-white rounded px-2 py-1">
+                    {{ DateTime.fromJSDate(step.receivedAt).toISO()?.replace(/T/gi, ' ') }}
+                  </TooltipContent>
+                </TooltipPortal>
+              </TooltipRoot>
+            </TooltipProvider>
+          </p>
+          <p v-else class="ml-8 mb-4 text-sm text-black dark:text-white">
+            No git commit available in API response. Can't publish until this is verified.
+          </p>
+          <BaseCard>
+            <div class="w-full">
+              <DiffTable v-if="step.metadataCompare" :columns="diffColumns" :rows="step.metadataCompare" />
+              <p v-else class="text-center">(no diff available)</p>
+            </div>
+          </BaseCard>
           <div v-if="step.headSha" class="flex justify-between mx-6 mt-10 mb-10">
             <div>
               <BaseButton btn-type="cancel" @click="cancel">
@@ -128,12 +139,10 @@
               </BaseButton>
             </div>
             <div>
-              <template v-if="step.headSha">
-                <BaseButton btn-type="secondary"
-                  @click="() => step.type === 'diff' && step.headSha ? deleteMetadataValidationAndRetry(step.headSha) : console.error('internal error unhandled state (1)', step)">
-                  Redo metadata validation
-                </BaseButton>
-              </template>
+              <BaseButton btn-type="secondary"
+                @click="deleteMetadataValidationAndRetry">
+                Redo metadata validation
+              </BaseButton>
             </div>
             <div class="flex gap-2 justify-end">
               <BaseButton v-if="step.canAutofix" btn-type="default" @click="metadataValidationResultsSyncHandler">
@@ -143,14 +152,6 @@
                 Publish this RFC
               </BaseButton>
             </div>
-          </div>
-        </template>
-        <template v-else>
-          <div class="flex justify-center mt-8 pt-4 border-t border-gray-300 dark:border-gray-300">
-            <BaseButton btn-type="secondary"
-              @click="() => step.type === 'diff' && step.headSha ? deleteMetadataValidationAndRetry(step.headSha) : fetchAndVerifyMetadata()">
-              Redo metadata validation
-            </BaseButton>
           </div>
         </template>
       </template>
@@ -247,7 +248,7 @@ type Step =
   | { type: 'getMetadataValidationResults' }
   | { type: 'fetchAndVerifyAndMetadataButton' }
   | { type: 'loading' }
-  | { type: 'error', errorText: string, showResyncButton?: boolean, showDeleteAndRetryButton?: { headSha: string } }
+  | { type: 'error', errorText: string, showResyncButton?: boolean, showDeleteAndRetryButton?: boolean }
   | {
     type: 'diff'
     error?: string
@@ -319,7 +320,7 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
     step.value = {
       type: 'error',
       errorText: `Unable to load RFC ${draftName.value}. Server error: ${rfcToBeError.value?.message ?? ''} ${metadataValidationResultsError.value ?? ''}`,
-      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) && precomputedResult?.headSha ? { headSha: precomputedResult.headSha } : undefined,
+      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) && !!precomputedResult?.headSha,
       showResyncButton: true
     }
     return
@@ -398,6 +399,11 @@ const MAXIMUM_ATTEMPTS_DURATION_MS = 10 * 1000
 const WAIT_BETWEEN_REQUESTS_MS = 1000
 
 const fetchAndVerifyMetadata = async () => {
+  if (!rfcToBe.value?.repository) {
+    snackbar.add({ type: 'warning', title: 'No repository set', text: 'Set a repository URL on this document before validating metadata.' })
+    return
+  }
+
   let resultsCreate: MetadataValidationResults | undefined = undefined
 
   step.value = { type: 'loading' }
@@ -423,7 +429,7 @@ const fetchAndVerifyMetadata = async () => {
     step.value = {
       type: 'error',
       errorText: `Couldn't start/poll for metadata sync results. Error: ${error}`,
-      showDeleteAndRetryButton: resultsCreate?.headSha ? { headSha: resultsCreate.headSha } : undefined,
+      showDeleteAndRetryButton: !!resultsCreate?.headSha,
       showResyncButton: true
     }
     if (!resultsCreate) {
@@ -433,25 +439,7 @@ const fetchAndVerifyMetadata = async () => {
 
   console.log("Finished", { hasTimedOut, resultsCreate })
 
-  if (resultsCreate.status === 'failed') {
-    const { headSha, detail } = resultsCreate
-    if (detail) {
-      console.error("Metadata validation failed", resultsCreate)
-      step.value = { type: 'error', errorText: `Details: ${detail}`, showResyncButton: true }
-      return
-    }
-    if (!headSha) {
-      console.error("Git hash (head sha) not found", resultsCreate)
-      snackbar.add({ type: 'error', title: 'git hash (head sha) was expected but none was provided', text: 'See dev console for more' })
-      return
-    }
-    step.value = {
-      type: 'error',
-      errorText: `Failed to validate metadata. Request status was still ${JSON.stringify(resultsCreate.status)}.`,
-      showDeleteAndRetryButton: { headSha },
-      showResyncButton: true
-    }
-  } else if (resultsCreate.status !== 'success') {
+  if (resultsCreate.status !== 'success' && resultsCreate.status !== 'failed') {
     step.value = {
       type: 'error',
       errorText: `Failed to validate metadata. Request status was still ${JSON.stringify(resultsCreate.status)}.`,
@@ -466,29 +454,23 @@ const fetchAndVerifyMetadata = async () => {
   }
 }
 
-const deleteMetadataValidationAndRetry = async (headSha?: string) => {
-  if (!headSha) {
-    console.trace()
-    console.error("no git hash (head sha) found at step", step.value)
-    snackbar.add({ type: 'error', title: 'internal error, expected git hash (head sha) param', text: 'See dev console for more' })
-    return
-  }
+const deleteMetadataValidationAndRetry = async () => {
   step.value = { type: 'loading' }
   try {
     await api.documentsMetadataValidationResultsDestroy({
-      draftName: draftName.value,
-      headSha
+      draftName: draftName.value
     })
-    fetchAndVerifyMetadata()
   } catch (error: unknown) {
     snackbarForErrors({ snackbar, error, defaultTitle: "Couldn't delete validation results" })
     step.value = {
       type: 'error',
       errorText: "Couldn't delete validation results",
-      showDeleteAndRetryButton: { headSha },
+      showDeleteAndRetryButton: true,
       showResyncButton: true
     }
+    return
   }
+  fetchAndVerifyMetadata()
 }
 
 const publishRfc = async () => {
@@ -560,7 +542,7 @@ const metadataValidationResultsSyncHandler = async () => {
 }
 
 const cancel = () => {
-  step.value = { type: "cancelled" }
+  step.value = { type: 'cancelled' }
 }
 
 const syncCurrentMetadata = async () => {

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -1860,16 +1860,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/MetadataValidationResults'
           description: ''
-  /api/rpc/documents/{draft_name}/metadata_validation_results/delete/:
     delete:
       operationId: metadata_validation_results_delete
-      description: Delete metadata validation results for a given RfcToBe.
+      description: |-
+        Delete metadata validation results for a given RfcToBe, identified by head_sha.
+        Pass the sentinel value "no_head_sha" to delete a record whose head_sha is NULL
+        (i.e. the validation task failed before a git commit was fetched).
       parameters:
       - in: path
         name: draft_name
         schema:
           type: string
-        description: Draft name
+        required: true
+      - in: path
+        name: head_sha
+        schema:
+          type: string
+        description: Head SHA of the git commit the validation was run against
         required: true
       tags:
       - purple

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -1860,19 +1860,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/MetadataValidationResults'
           description: ''
+  /api/rpc/documents/{draft_name}/metadata_validation_results/delete/:
     delete:
-      operationId: documents_metadata_validation_results_destroy
+      operationId: metadata_validation_results_delete
+      description: Delete metadata validation results for a given RfcToBe.
       parameters:
       - in: path
         name: draft_name
         schema:
           type: string
-        required: true
-      - in: path
-        name: head_sha
-        schema:
-          type: string
-          description: Head SHA of the commit that was validated
+        description: Draft name
         required: true
       tags:
       - purple
@@ -1881,6 +1878,18 @@ paths:
       responses:
         '204':
           description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteMetadataBadRequestResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteMetadataNotFoundResponse'
+          description: ''
   /api/rpc/documents/{draft_name}/metadata_validation_results/sync/:
     post:
       operationId: metadata_validation_results_sync
@@ -4008,6 +4017,20 @@ components:
           type: integer
       required:
       - person_id
+    DeleteMetadataBadRequestResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
+    DeleteMetadataNotFoundResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     DocumentComment:
       type: object
       description: Serialize a comment on an RfcToBe

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -4388,9 +4388,7 @@ components:
           readOnly: true
         head_sha:
           type: string
-          nullable: true
-          description: Head SHA of the commit that was validated
-          maxLength: 40
+          readOnly: true
         can_autofix:
           type: boolean
           readOnly: true

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -85,6 +85,7 @@ from .models import (
 from .pagination import DefaultLimitOffsetPagination
 from .rfcindex import mark_rfcindex_as_dirty
 from .serializers import (
+    NO_HEAD_SHA_SENTINEL,
     ActionHolderSerializer,
     AdditionalEmailSerializer,
     ApprovalLogMessageSerializer,
@@ -2219,9 +2220,6 @@ class SubseriesTypeNameViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = SubseriesTypeName.objects.all()
     serializer_class = SubseriesTypeNameSerializer
-
-
-NO_HEAD_SHA_SENTINEL = "no_head_sha"
 
 
 @extend_schema_with_draft_name()

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -2221,12 +2221,23 @@ class SubseriesTypeNameViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = SubseriesTypeNameSerializer
 
 
+NO_HEAD_SHA_SENTINEL = "no_head_sha"
+
+
 @extend_schema_with_draft_name()
 class MetadataValidationResultsViewSet(viewsets.ModelViewSet):
     queryset = MetadataValidationResults.objects.all()
     serializer_class = MetadataValidationResultsSerializer
     http_method_names = ["get", "post", "delete"]
     lookup_field = "head_sha"
+
+    def get_object(self):
+        if self.kwargs.get(self.lookup_field) == NO_HEAD_SHA_SENTINEL:
+            queryset = self.filter_queryset(self.get_queryset())
+            obj = get_object_or_404(queryset, head_sha__isnull=True)
+            self.check_object_permissions(self.request, obj)
+            return obj
+        return super().get_object()
 
     def get_queryset(self):
         return (
@@ -2288,6 +2299,12 @@ class MetadataValidationResultsViewSet(viewsets.ModelViewSet):
                 location=OpenApiParameter.PATH,
                 description="Draft name",
             ),
+            OpenApiParameter(
+                name="head_sha",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="Head SHA of the git commit the validation was run against",
+            ),
         ],
         responses={
             204: None,
@@ -2301,16 +2318,13 @@ class MetadataValidationResultsViewSet(viewsets.ModelViewSet):
             ),
         },
     )
-    @action(detail=False, methods=["delete"])
-    def delete(self, request, *args, **kwargs):
+    def destroy(self, request, *args, **kwargs):
         """
-        Delete metadata validation results for a given RfcToBe.
+        Delete metadata validation results for a given RfcToBe, identified by head_sha.
+        Pass the sentinel value "no_head_sha" to delete a record whose head_sha is NULL
+        (i.e. the validation task failed before a git commit was fetched).
         """
-        draft_name = kwargs.get("draft_name")
-        rfc_to_be = resolve_rfctobe(draft_name)
-        metadata_result = get_object_or_404(
-            MetadataValidationResults, rfc_to_be=rfc_to_be
-        )
+        metadata_result = self.get_object()
 
         if metadata_result.status == MetadataValidationResults.Status.PENDING:
             return Response(

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -2301,6 +2301,7 @@ class MetadataValidationResultsViewSet(viewsets.ModelViewSet):
             ),
         },
     )
+    @action(detail=False, methods=["delete"])
     def delete(self, request, *args, **kwargs):
         """
         Delete metadata validation results for a given RfcToBe.

--- a/rpc/lifecycle/repo.py
+++ b/rpc/lifecycle/repo.py
@@ -104,7 +104,14 @@ class GithubRepository(Repository):
             if auth_token is not None:
                 auth = GithubAuthToken(auth_token)
         self.gh = Github(auth=auth)
-        self.repo = self.gh.get_repo(repo_id)
+        try:
+            self.repo = self.gh.get_repo(repo_id)
+        except GithubException as err:
+            if err.status == 404:
+                raise RepositoryError(
+                    f"Repository '{repo_id}' was not found or is not accessible."
+                ) from err
+            raise
         self._ref: str | None = None
 
     def get_manifest(self):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1786,8 +1786,12 @@ class MetadataComparisonTableSerializer(serializers.Serializer):
         return super().to_representation(obj)
 
 
+NO_HEAD_SHA_SENTINEL = "no_head_sha"
+
+
 class MetadataValidationResultsSerializer(serializers.ModelSerializer):
     repository = serializers.CharField(source="rfc_to_be.repository", read_only=True)
+    head_sha = serializers.SerializerMethodField()
     can_autofix = serializers.SerializerMethodField()
     is_match = serializers.SerializerMethodField()
     metadata_compare = serializers.SerializerMethodField()
@@ -1809,6 +1813,10 @@ class MetadataValidationResultsSerializer(serializers.ModelSerializer):
             "is_error",
             "received_at",
         ]
+
+    @extend_schema_field(serializers.CharField())
+    def get_head_sha(self, obj):
+        return obj.head_sha if obj.head_sha is not None else NO_HEAD_SHA_SENTINEL
 
     def _get_comparator(self, obj):
         """Get or create a cached MetadataComparator for this object"""


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1130 and fix https://github.com/ietf-tools/purple/issues/1127 and fix https://github.com/ietf-tools/purple/issues/1046

general overhaul of the page:

- allow for deleting failed MetadataResults (without head_sha), which is required to re-fetch a previously failed request (which doesn't have the sha)
- show error message immediately if no repo set (don't call API)
- show dedicated error message if repo is set, but not reachable

Only show "Try again" if previous call failed, without the other data
