### PR TITLE
feat: show publication validation/auth errors in UI

### DIFF
--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -505,8 +505,9 @@ const publishRfc = async () => {
     let errorText = `${e}`
     if (typeof e === 'object' && e !== null && 'response' in e) {
       try {
-        const { detail } = await (e as { response: Response }).response.json()
-        if (detail) errorText = String(detail)
+        const body = await (e as { response: Response }).response.json()
+        const msg = body.non_field_errors ?? body.detail ?? Object.values(body)[0]
+        if (msg) errorText = String(msg)
       } catch { /* keep default */ }
     }
     snackbar.add({ type: 'error', title: 'Cannot publish', text: errorText })

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -230,7 +230,7 @@ import { TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTri
 import { useAsyncData } from '#app'
 import { DateTime } from 'luxon'
 import BaseButton from '~/components/BaseButton.vue'
-import type { MetadataValidationResults } from '~/purple_client'
+import { ResponseError, type MetadataValidationResults } from '~/purple_client'
 import { type DocTabId } from '~/utils/doc'
 
 const route = useRoute()
@@ -503,10 +503,10 @@ const publishRfc = async () => {
     setTimeout(publicationStatusRefresh, PUBLICATION_STATUS_POLL_INTERVAL_MS)
   } catch (e: unknown) {
     let errorText = `${e}`
-    if (typeof e === 'object' && e !== null && 'response' in e) {
+    if (e instanceof ResponseError) {
       try {
-        const body = await (e as { response: Response }).response.json()
-        const msg = body.non_field_errors ?? body.detail ?? Object.values(body)[0]
+        const body = await e.response.json()
+        const msg = body.detail ?? Object.values(body)[0]
         if (msg) errorText = String(msg)
       } catch { /* keep default */ }
     }

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -502,10 +502,15 @@ const publishRfc = async () => {
     }
     setTimeout(publicationStatusRefresh, PUBLICATION_STATUS_POLL_INTERVAL_MS)
   } catch (e: unknown) {
-    step.value = {
-      type: 'rfcPosted',
-      error: `Problem publishing: ${e}`
+    let errorText = `${e}`
+    if (typeof e === 'object' && e !== null && 'response' in e) {
+      try {
+        const { detail } = await (e as { response: Response }).response.json()
+        if (detail) errorText = String(detail)
+      } catch { /* keep default */ }
     }
+    snackbar.add({ type: 'error', title: 'Cannot publish', text: errorText })
+    step.value = { type: 'rfcPosted', error: errorText }
   }
 }
 

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -794,6 +794,18 @@ paths:
       responses:
         '200':
           description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublishValidationError'
+          description: Document is not ready to publish
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublishPermissionDenied'
+          description: User is not permitted to publish this RFC
   /api/rpc/documents/{draft__name}/sync_metadata/:
     post:
       operationId: documents_sync_metadata
@@ -5019,6 +5031,13 @@ components:
       - std_level
       - stream
       - title
+    PublishPermissionDenied:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     PublishRfcRequest:
       type: object
       properties:
@@ -5040,6 +5059,17 @@ components:
       required:
       - detail
       - status
+    PublishValidationError:
+      type: object
+      properties:
+        non_field_errors:
+          type: string
+        disposition:
+          type: string
+        rfc_number:
+          type: string
+        repository:
+          type: string
     QueueItem:
       type: object
       description: RfcToBe serializer suitable for displaying a queue of many

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -21,6 +21,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
+    OpenApiResponse,
     extend_schema,
     extend_schema_view,
     inline_serializer,
@@ -1094,7 +1095,28 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
     @extend_schema(
         operation_id="documents_publish",
         request=PublishRfcSerializer,
-        responses=None,
+        responses={
+            200: None,
+            400: OpenApiResponse(
+                description="Document is not ready to publish",
+                response=inline_serializer(
+                    "PublishValidationError",
+                    fields={
+                        "non_field_errors": serializers.CharField(required=False),
+                        "disposition": serializers.CharField(required=False),
+                        "rfc_number": serializers.CharField(required=False),
+                        "repository": serializers.CharField(required=False),
+                    },
+                ),
+            ),
+            403: OpenApiResponse(
+                description="User is not permitted to publish this RFC",
+                response=inline_serializer(
+                    "PublishPermissionDenied",
+                    fields={"detail": serializers.CharField()},
+                ),
+            ),
+        },
     )
     @action(detail=True, methods=["post"])
     def publish(self, request, draft__name=None):

--- a/rpc/lifecycle/publication.py
+++ b/rpc/lifecycle/publication.py
@@ -60,7 +60,10 @@ def validate_ready_to_publish(rfctobe: RfcToBe):
     """
     if rfctobe.disposition_id != "in_progress":
         raise serializers.ValidationError(
-            {"disposition": f"disposition is '{rfctobe.disposition}', not 'In Progress'"},
+            {
+                "disposition": f"disposition is '{rfctobe.disposition}', "
+                "not 'In Progress'"
+            },
             code="rfctobe-bad-disposition",
         )
     if rfctobe.assignment_set.active().exclude(role_id="publisher").exists():

--- a/rpc/lifecycle/publication.py
+++ b/rpc/lifecycle/publication.py
@@ -60,36 +60,36 @@ def validate_ready_to_publish(rfctobe: RfcToBe):
     """
     if rfctobe.disposition_id != "in_progress":
         raise serializers.ValidationError(
-            {"detail": f"disposition is '{rfctobe.disposition}, not 'In Progress'"},
+            {"disposition": f"disposition is '{rfctobe.disposition}', not 'In Progress'"},
             code="rfctobe-bad-disposition",
         )
     if rfctobe.assignment_set.active().exclude(role_id="publisher").exists():
         raise serializers.ValidationError(
-            {"detail": "document has open assignments other than publisher"},
+            {"non_field_errors": "document has open assignments other than publisher"},
             code="rfctobe-open-assignments",
         )
     if not rfctobe.assignment_set.active().filter(role_id="publisher").exists():
         raise serializers.ValidationError(
-            {"detail": "document is not assigned a publisher"},
+            {"non_field_errors": "document is not assigned a publisher"},
             code="rfctobe-no-publisher",
         )
     if rfctobe.finalapproval_set.count() == 0:
         raise serializers.ValidationError(
-            {"detail": "no final approvals have been completed"},
+            {"non_field_errors": "no final approvals have been completed"},
             code="rfctobe-no-final-approvals",
         )
     if rfctobe.finalapproval_set.active().exists():
         raise serializers.ValidationError(
-            {"detail": "final approvals are pending"},
+            {"non_field_errors": "final approvals are pending"},
             code="rfctobe-pending-final-approvals",
         )
     if rfctobe.rfc_number is None:
         raise serializers.ValidationError(
-            {"detail": "no RFC number is assigned"},
+            {"rfc_number": "no RFC number is assigned"},
             code="rfctobe-no-rfc-number",
         )
     if rfctobe.repository.strip() == "":
-        raise serializers.ValidationError({"detail": "no repository is configured"})
+        raise serializers.ValidationError({"repository": "no repository is configured"})
     # todo IANA check, what else?
 
 
@@ -273,7 +273,9 @@ def publish_rfctobe(
     try:
         validate_ready_to_publish(rfctobe)
     except serializers.ValidationError as err:
-        raise PublicationError(f"Cannot publish because {err}") from err
+        errors = err.detail.get("non_field_errors", [])
+        msg = str(errors[0]) if errors else str(err.detail)
+        raise PublicationError(f"Cannot publish because {msg}") from err
 
     repo = GithubRepository(rfctobe.repository)
     # Check that head commit matches expected_head. This check defines the instant

--- a/rpc/lifecycle/publication.py
+++ b/rpc/lifecycle/publication.py
@@ -276,8 +276,8 @@ def publish_rfctobe(
     try:
         validate_ready_to_publish(rfctobe)
     except serializers.ValidationError as err:
-        errors = err.detail.get("non_field_errors", [])
-        msg = str(errors[0]) if errors else str(err.detail)
+        first = next(iter(err.detail.values()), None)
+        msg = str(first) if first is not None else str(err.detail)
         raise PublicationError(f"Cannot publish because {msg}") from err
 
     repo = GithubRepository(rfctobe.repository)

--- a/rpc/lifecycle/publication.py
+++ b/rpc/lifecycle/publication.py
@@ -60,36 +60,36 @@ def validate_ready_to_publish(rfctobe: RfcToBe):
     """
     if rfctobe.disposition_id != "in_progress":
         raise serializers.ValidationError(
-            f"disposition is '{rfctobe.disposition}, not 'In Progress'",
+            {"detail": f"disposition is '{rfctobe.disposition}, not 'In Progress'"},
             code="rfctobe-bad-disposition",
         )
     if rfctobe.assignment_set.active().exclude(role_id="publisher").exists():
         raise serializers.ValidationError(
-            "document has open assignments other than publisher",
+            {"detail": "document has open assignments other than publisher"},
             code="rfctobe-open-assignments",
         )
     if not rfctobe.assignment_set.active().filter(role_id="publisher").exists():
         raise serializers.ValidationError(
-            "document is not assigned a publisher",
+            {"detail": "document is not assigned a publisher"},
             code="rfctobe-no-publisher",
         )
     if rfctobe.finalapproval_set.count() == 0:
         raise serializers.ValidationError(
-            "no final approvals have been completed",
+            {"detail": "no final approvals have been completed"},
             code="rfctobe-no-final-approvals",
         )
     if rfctobe.finalapproval_set.active().exists():
         raise serializers.ValidationError(
-            "final approvals are pending",
+            {"detail": "final approvals are pending"},
             code="rfctobe-pending-final-approvals",
         )
     if rfctobe.rfc_number is None:
         raise serializers.ValidationError(
-            "no RFC number is assigned",
+            {"detail": "no RFC number is assigned"},
             code="rfctobe-no-rfc-number",
         )
     if rfctobe.repository.strip() == "":
-        raise serializers.ValidationError("no repository is configured")
+        raise serializers.ValidationError({"detail": "no repository is configured"})
     # todo IANA check, what else?
 
 


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/1151

Will show errors/details why publication is blocked in UI/snackbar

I also changed the _gestalt_ of the JSON validation response (to streamline with Auth response):

```
Before: ["document has open assignments other than publisher"]

After: {"detail": "document has open assignments other than publisher"}
```

