### PR TITLE
fix: cluster handling for not-received

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -183,16 +183,17 @@ def apply_submission_cluster_membership(
     current_doc: Document,
     reference_docs: list[Document],
     received_reference_ids: set[int],
+    has_not_received_refs: bool = False,
 ) -> Cluster | None:
     """Place imported document into an existing reference cluster or create a new one.
 
     If any received reference is already clustered, the current document joins that
     cluster. Otherwise, create a new cluster and add the current document and all
-    reference documents that are not already clustered. If there are no references,
-    do not create a cluster.
+    reference documents that are not already clustered. If there are no references
+    received or not, do not create a cluster.
     """
 
-    if not reference_docs and not received_reference_ids:
+    if not reference_docs and not received_reference_ids and not has_not_received_refs:
         return None
 
     existing_member = (
@@ -516,12 +517,14 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
             # if "not-received" references exist, change them to "refqueue"
             # if "not-received-2/3g" references exist, delete them
             recompute_source_ids: set[int] = set()
+            upgraded_source_docs: list[Document] = []
+            upgraded_source_datatracker_ids: set[int] = set()
             existing_references = RpcRelatedDocument.objects.filter(
                 target_document__name=rfctobe.draft.name,
                 relationship__slug__in=(
                     DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUGS
                 ),
-            )
+            ).select_related("source__draft")
             for existing_reference in existing_references:
                 if (
                     existing_reference.relationship.slug
@@ -531,6 +534,10 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                         slug=DocRelationshipName.REFQUEUE_RELATIONSHIP_SLUG
                     )
                     existing_reference.save()
+                    source_draft = existing_reference.source.draft
+                    upgraded_source_docs.append(source_draft)
+                    if source_draft.datatracker_id is not None:
+                        upgraded_source_datatracker_ids.add(source_draft.datatracker_id)
                 else:
                     if (
                         existing_reference.relationship.slug
@@ -539,6 +546,13 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                         # schedule recomputation to clean up deleted 2G references.
                         recompute_source_ids.add(existing_reference.source_id)
                     existing_reference.delete()
+
+            if upgraded_source_docs:
+                apply_submission_cluster_membership(
+                    current_doc=rfctobe.draft,
+                    reference_docs=upgraded_source_docs,
+                    received_reference_ids=upgraded_source_datatracker_ids,
+                )
 
             for source_id in recompute_source_ids:
                 ref_1g = RpcRelatedDocument.objects.filter(
@@ -566,6 +580,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
             )
             reference_docs: list[Document] = []
             received_reference_ids: set[int] = set()
+            has_not_received_refs = False
             for reference in references:
                 # Create a RelatedDoc for each normative reference
                 if reference.id not in existing_rfc_to_be:
@@ -591,6 +606,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                             },
                         )
                     create_rpc_related_document("not-received", rfctobe.pk, draft.name)
+                    has_not_received_refs = True
                 else:
                     disposition = existing_rfc_to_be[reference.id]
                     if disposition in ("created", "in_progress"):
@@ -623,6 +639,7 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
                 current_doc=rfctobe.draft,
                 reference_docs=reference_docs,
                 received_reference_ids=received_reference_ids,
+                has_not_received_refs=has_not_received_refs,
             )
 
             transaction.on_commit(lambda: set_stream_manager_task.delay(rfctobe.pk))

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -189,7 +189,7 @@ def apply_submission_cluster_membership(
 
     If any received reference is already clustered, the current document joins that
     cluster. Otherwise, create a new cluster and add the current document and all
-    reference documents that are not already clustered. If there are no references
+    reference documents that are not already clustered. If there are no references,
     received or not, do not create a cluster.
     """
 

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -5,7 +5,6 @@ from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 
 import rpcapi_client
-
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import TestCase

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -1,23 +1,48 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
 
 import json
-from unittest.mock import patch
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.exceptions import NotFound
 
-from rpc.models import DocRelationshipName
+from datatracker.factories import DocumentFactory
+from datatracker.models import Document
+from rpc.models import DocRelationshipName, RpcRelatedDocument
 
-from .api import resolve_rfctobe
+from .api import apply_submission_cluster_membership, resolve_rfctobe
 from .factories import (
     ClusterFactory,
     DispositionNameFactory,
     RfcToBeFactory,
+    SourceFormatNameFactory,
+    StdLevelNameFactory,
+    StreamNameFactory,
+    TlpBoilerplateChoiceNameFactory,
     UnusableRfcNumberFactory,
 )
 from .utils import next_rfc_number
+
+# Minimal data that rpcapi_client.FullDraft.from_json() accepts
+_FULL_DRAFT_BASE = {
+    "rev": "00",
+    "stream": "ietf",
+    "title": "",
+    "group": "",
+    "abstract": "",
+    "pages": 10,
+    "shepherd": None,
+    "ad": None,
+    "consensus": None,
+    "source_format": None,
+    "intended_std_level": None,
+    "authors": [],
+    "wg_chairs": [],
+}
 
 
 class GetRfcToBeForDraftNameTests(TestCase):
@@ -147,6 +172,219 @@ class RelatedDocumentClusterSyncTests(TestCase):
 
         target.refresh_from_db()
         self.assertEqual(target.cluster.number, cluster.number)
+
+
+class ApplySubmissionClusterMembershipTests(TestCase):
+    def test_no_refs_creates_no_cluster(self):
+        doc = RfcToBeFactory().draft
+        result = apply_submission_cluster_membership(
+            current_doc=doc,
+            reference_docs=[],
+            received_reference_ids=set(),
+            has_not_received_refs=False,
+        )
+        self.assertIsNone(result)
+        self.assertFalse(doc.clustermember_set.exists())
+
+    def test_not_received_refs_creates_cluster_for_current_doc_only(self):
+        """Draft A with only not-received references gets a single-doc cluster."""
+        doc_a = RfcToBeFactory().draft
+        result = apply_submission_cluster_membership(
+            current_doc=doc_a,
+            reference_docs=[],
+            received_reference_ids=set(),
+            has_not_received_refs=True,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(list(result.docs.all()), [doc_a])
+
+    def test_later_received_doc_joins_waiting_cluster(self):
+        """Draft B, imported after A, joins A's existing cluster."""
+        doc_a = RfcToBeFactory().draft
+        cluster_a = apply_submission_cluster_membership(
+            current_doc=doc_a,
+            reference_docs=[],
+            received_reference_ids=set(),
+            has_not_received_refs=True,
+        )
+
+        # B is now imported; A's cluster is found via its datatracker_id
+        doc_b = DocumentFactory(pages=1)
+        apply_submission_cluster_membership(
+            current_doc=doc_b,
+            reference_docs=[doc_a],
+            received_reference_ids={doc_a.datatracker_id},
+        )
+
+        doc_b.refresh_from_db()
+        self.assertEqual(doc_b.clustermember_set.get().cluster, cluster_a)
+
+    def test_later_received_doc_creates_cluster_if_source_unclustered(self):
+        """If A somehow has no cluster, importing B creates one for both."""
+        doc_a = RfcToBeFactory().draft
+        doc_b = DocumentFactory(pages=1)
+
+        apply_submission_cluster_membership(
+            current_doc=doc_b,
+            reference_docs=[doc_a],
+            received_reference_ids={doc_a.datatracker_id},
+        )
+
+        doc_a.refresh_from_db()
+        doc_b.refresh_from_db()
+        cluster_a = doc_a.clustermember_set.get().cluster
+        cluster_b = doc_b.clustermember_set.get().cluster
+        self.assertEqual(cluster_a, cluster_b)
+
+    def test_not_received_upgrade_clusters_b_with_existing_a_cluster(self):
+        """Simulates the upgrade path: not-received→refqueue puts B in A's cluster."""
+        not_received_rel, _ = DocRelationshipName.objects.get_or_create(
+            slug="not-received", defaults={"name": "Not Received", "desc": ""}
+        )
+        rfctobe_a = RfcToBeFactory()
+        doc_b = DocumentFactory(pages=1)
+
+        # A has a cluster (created when A was imported with not-received ref to B)
+        cluster_a = apply_submission_cluster_membership(
+            current_doc=rfctobe_a.draft,
+            reference_docs=[],
+            received_reference_ids=set(),
+            has_not_received_refs=True,
+        )
+
+        # Record the not-received relationship from A → B
+        RpcRelatedDocument.objects.create(
+            source=rfctobe_a,
+            relationship=not_received_rel,
+            target_document=doc_b,
+        )
+
+        # B is now imported: the upgrade path clusters B with A
+        apply_submission_cluster_membership(
+            current_doc=doc_b,
+            reference_docs=[rfctobe_a.draft],
+            received_reference_ids={rfctobe_a.draft.datatracker_id},
+        )
+
+        doc_b.refresh_from_db()
+        self.assertEqual(doc_b.clustermember_set.get().cluster, cluster_a)
+
+
+@patch("rpc.serializers.compute_deep_references_task")
+@patch("rpc.api.set_stream_manager_task")
+class ImportSubmissionClusteringTests(TestCase):
+    """Integration tests: import_submission creates/joins clusters correctly."""
+
+    def setUp(self):
+        cache.clear()
+        self.user = get_user_model().objects.create_user(
+            username="import-cluster-user",
+            password="test-password",
+            name="Import Cluster User",
+        )
+        self.client.force_login(self.user)
+        self.fmt = SourceFormatNameFactory(slug="xml-v3")
+        self.boilerplate = TlpBoilerplateChoiceNameFactory(slug="trust200902")
+        self.std_level = StdLevelNameFactory(slug="ps")
+        self.stream = StreamNameFactory(slug="ietf")
+
+    def _make_rpcapi(self, drafts_by_id, refs_by_id=None):
+        """Return a mock rpcapi configured for the given drafts and references.
+
+        drafts_by_id: {doc_id: draft_name}
+        refs_by_id:   {doc_id: {ref_id: ref_name}} — defaults to no refs
+        """
+        refs_by_id = refs_by_id or {}
+        mock = MagicMock()
+
+        def _draft(doc_id, name):
+            d = MagicMock()
+            d.name = name
+            d.rev = "00"
+            d.title = f"Test: {name}"
+            d.group = ""
+            d.stream = "ietf"
+            d.pages = 10
+            d.intended_std_level = ""
+            d.consensus = None
+            d.json.return_value = json.dumps(
+                _FULL_DRAFT_BASE | {"id": doc_id, "name": name}
+            )
+            return d
+
+        draft_map = {
+            doc_id: _draft(doc_id, name) for doc_id, name in drafts_by_id.items()
+        }
+        mock.get_draft_by_id.side_effect = lambda doc_id: draft_map.get(doc_id)
+
+        def _refs(doc_id):
+            result = []
+            for ref_id, ref_name in refs_by_id.get(doc_id, {}).items():
+                ref = MagicMock()
+                ref.id = ref_id
+                ref.name = ref_name
+                result.append(ref)
+            return result
+
+        mock.get_draft_references.side_effect = _refs
+        return mock
+
+    def _do_import(self, document_id, rpcapi):
+        data = {
+            "submitted_format": self.fmt.pk,
+            "boilerplate": self.boilerplate.pk,
+            "std_level": self.std_level.pk,
+            "stream": self.stream.pk,
+            "external_deadline": (date.today() + timedelta(days=30)).isoformat(),
+            "labels": [],
+        }
+        with patch("datatracker.rpcapi.get_rpcapi_client", return_value=rpcapi):
+            return self.client.post(
+                f"/api/rpc/submissions/{document_id}/import/",
+                data=json.dumps(data),
+                content_type="application/json",
+            )
+
+    def test_import_a_with_not_received_b_creates_cluster(self, mock_sst, mock_cdr):
+        """A imported with an unreceived normative ref to B → A gets its own cluster."""
+        A_ID, B_ID = 1001, 1002
+        rpcapi = self._make_rpcapi(
+            drafts_by_id={A_ID: "draft-cluster-a", B_ID: "draft-cluster-b"},
+            refs_by_id={A_ID: {B_ID: "draft-cluster-b"}},
+        )
+        response = self._do_import(A_ID, rpcapi)
+        self.assertEqual(response.status_code, 200, response.content)
+
+        doc_a = Document.objects.get(datatracker_id=A_ID)
+        self.assertTrue(
+            doc_a.clustermember_set.exists(),
+            "A should be placed in a cluster when it has a not-received reference",
+        )
+
+    def test_import_b_after_a_joins_same_cluster(self, mock_sst, mock_cdr):
+        """B imported after A (which had a not-received ref to B) joins A's cluster."""
+        A_ID, B_ID = 2001, 2002
+
+        # Step 1 – import A; B is not yet in the queue
+        rpcapi_a = self._make_rpcapi(
+            drafts_by_id={A_ID: "draft-join-a", B_ID: "draft-join-b"},
+            refs_by_id={A_ID: {B_ID: "draft-join-b"}},
+        )
+        resp = self._do_import(A_ID, rpcapi_a)
+        self.assertEqual(resp.status_code, 200, resp.content)
+
+        # Step 2 – import B; its own normative reference list is empty
+        rpcapi_b = self._make_rpcapi(
+            drafts_by_id={B_ID: "draft-join-b"},
+        )
+        resp = self._do_import(B_ID, rpcapi_b)
+        self.assertEqual(resp.status_code, 200, resp.content)
+
+        doc_a = Document.objects.get(datatracker_id=A_ID)
+        doc_b = Document.objects.get(datatracker_id=B_ID)
+        cluster_a = doc_a.clustermember_set.get().cluster
+        cluster_b = doc_b.clustermember_set.get().cluster
+        self.assertEqual(cluster_a, cluster_b, "A and B must be in the same cluster")
 
 
 class DocumentSearchTests(TestCase):

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -284,16 +284,19 @@ class ImportSubmissionClusteringTests(TestCase):
         mock = MagicMock()
 
         def _draft(doc_id, name):
-            d = MagicMock(spec=rpcapi_client.FullDraft)
-            d.name = name
-            d.rev = "00"
-            d.title = f"Test: {name}"
-            d.group = ""
-            d.stream = "ietf"
-            d.pages = 10
-            d.intended_std_level = ""
-            d.consensus = None
-            return d
+            return rpcapi_client.FullDraft(
+                id=doc_id,
+                name=name,
+                rev="00",
+                title=f"Test: {name}",
+                abstract="",
+                group="",
+                stream="ietf",
+                pages=10,
+                intended_std_level="",
+                consensus=None,
+                authors=[],
+            )
 
         draft_map = {
             doc_id: _draft(doc_id, name) for doc_id, name in drafts_by_id.items()
@@ -301,13 +304,10 @@ class ImportSubmissionClusteringTests(TestCase):
         mock.get_draft_by_id.side_effect = lambda doc_id: draft_map.get(doc_id)
 
         def _refs(doc_id):
-            result = []
-            for ref_id, ref_name in refs_by_id.get(doc_id, {}).items():
-                ref = MagicMock()
-                ref.id = ref_id
-                ref.name = ref_name
-                result.append(ref)
-            return result
+            return [
+                rpcapi_client.Reference(id=ref_id, name=ref_name)
+                for ref_id, ref_name in refs_by_id.get(doc_id, {}).items()
+            ]
 
         mock.get_draft_references.side_effect = _refs
         return mock

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -31,6 +31,7 @@ from .utils import next_rfc_number
 
 # Minimal data that rpcapi_client.FullDraft.from_json() accepts
 
+
 class GetRfcToBeForDraftNameTests(TestCase):
     def test_returns_match(self):
         rfctobe = RfcToBeFactory()

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -4,6 +4,8 @@ import json
 from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 
+import rpcapi_client
+
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import TestCase
@@ -28,22 +30,6 @@ from .factories import (
 from .utils import next_rfc_number
 
 # Minimal data that rpcapi_client.FullDraft.from_json() accepts
-_FULL_DRAFT_BASE = {
-    "rev": "00",
-    "stream": "ietf",
-    "title": "",
-    "group": "",
-    "abstract": "",
-    "pages": 10,
-    "shepherd": None,
-    "ad": None,
-    "consensus": None,
-    "source_format": None,
-    "intended_std_level": None,
-    "authors": [],
-    "wg_chairs": [],
-}
-
 
 class GetRfcToBeForDraftNameTests(TestCase):
     def test_returns_match(self):
@@ -298,7 +284,7 @@ class ImportSubmissionClusteringTests(TestCase):
         mock = MagicMock()
 
         def _draft(doc_id, name):
-            d = MagicMock()
+            d = MagicMock(spec=rpcapi_client.FullDraft)
             d.name = name
             d.rev = "00"
             d.title = f"Test: {name}"
@@ -307,9 +293,6 @@ class ImportSubmissionClusteringTests(TestCase):
             d.pages = 10
             d.intended_std_level = ""
             d.consensus = None
-            d.json.return_value = json.dumps(
-                _FULL_DRAFT_BASE | {"id": doc_id, "name": name}
-            )
             return d
 
         draft_map = {


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/1164 and fixes https://github.com/ietf-tools/purple/issues/1163

expected behavior:
when a new draft A enters the queue with a normative reference to draft B that is `not-received`, we should create a new cluster that contains (only) A.

When B eventually gets submitted, it will join A in same cluster.