### PR TITLE
fix: send sync_metadata and make editable

### DIFF
--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -99,7 +99,7 @@
         </DescriptionListItem>
         <DescriptionListItem term="Stream" :spacing="spacing">
           <DescriptionListDetails>
-            <PatchRfcToBeField fieldName="stream" :is-read-only="props.isReadOnly"
+            <PatchRfcToBeField fieldName="stream" :is-read-only="false"
               :ui-mode="{ type: 'select', options: loadStreams, initialValue: rfcToBe.stream }"
               :draft-name="rfcToBe.name ?? ''" :on-success="props.refresh">
               <span class="flex-1">

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -1195,14 +1195,10 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
                 )
                 for author in rfctobe.authors.all()
             ],
-            stream=rfctobe.publication_stream.slug
-            if rfctobe.publication_stream
-            else None,
+            stream=rfctobe.stream.slug,
             abstract=rfctobe.abstract,
             pages=rfctobe.pages,
-            std_level=rfctobe.publication_std_level.slug
-            if rfctobe.publication_std_level
-            else None,
+            std_level=rfctobe.std_level.slug,
             subseries=[
                 f"{m.type.slug}{m.number}" for m in rfctobe.subseriesmember_set.all()
             ],


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1178

for the `sync` we should send the CURRENT stream and std_level, not the ones at publication time

(on publication time they will be identical anyways, but for later changes we want to sync the current ones)