### PR TITLE
feat: let history be written for stream manager

### DIFF
--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -45,7 +45,8 @@ def set_stream_manager_task(rfc_to_be_id: int):
     if rfctobe.stream_manager_id is not None:
         return
     person = rfctobe.resolve_stream_manager_person()
-    RfcToBe.objects.filter(pk=rfc_to_be_id).update(stream_manager=person)
+    rfctobe.stream_manager = person
+    rfctobe.save(update_fields=["stream_manager"])
 
 
 logger = get_task_logger(__name__)


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1155

current implementation skips history and makes the change appear in history randomly with the next `save()`