### PR TITLE
fix: make consistent behavior resolve draft identifier

### DIFF
--- a/client/app/pages/docs/[id]/index.vue
+++ b/client/app/pages/docs/[id]/index.vue
@@ -6,7 +6,7 @@
 
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <ErrorAlert v-if="rawRfcToBeError" title="API Error">
-        API error while requesting draft: {{ rawRfcToBeError }}
+        {{ rfcToBeErrorMessage }}
       </ErrorAlert>
       <div v-else
         class="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 place-items-stretch gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
@@ -58,7 +58,7 @@
 <script setup lang="ts">
 import { DateTime } from 'luxon'
 import { useAsyncData } from '#app'
-import { snackbarForErrors } from "~/utils/snackbar"
+import { snackbarForErrors, getApiErrorMessage } from "~/utils/snackbar"
 import { type DocTabId } from '~/utils/doc'
 
 const route = useRoute()
@@ -78,7 +78,7 @@ const {
   refresh: commentsReload
 } = await useCommentsForDraft(draftName.value)
 
-const { data: rawRfcToBe, error: rawRfcToBeError, status: rfcToBeStatus, refresh: rfcToBeRefresh } = await useAsyncData(
+const { data: rawRfcToBe, error: rawRfcToBeError, refresh: rfcToBeRefresh } = await useAsyncData(
   () => `draft-${draftName.value}`,
   () => api.documentsRetrieve({ draftName: draftName.value }),
   {
@@ -87,6 +87,14 @@ const { data: rawRfcToBe, error: rawRfcToBeError, status: rfcToBeStatus, refresh
     deep: true // author editing relies on deep reactivity
   }
 )
+
+const rfcToBeErrorMessage = ref('')
+watch(rawRfcToBeError, async (err) => {
+  if (!err) { rfcToBeErrorMessage.value = ''; return }
+  const message = await getApiErrorMessage(err)
+  rfcToBeErrorMessage.value = message
+  snackbar.add({ type: 'error', title: 'API Error', text: message })
+}, { immediate: true })
 
 const initialSelectedLabelIds = computed(() => {
   console.log("recomputing initial selected label ids")

--- a/client/app/utils/snackbar.ts
+++ b/client/app/utils/snackbar.ts
@@ -10,6 +10,17 @@ type Props = {
 
 const MAX_TEXT_LENGTH = 100
 
+export const getApiErrorMessage = async (error: unknown): Promise<string> => {
+  const fetchResponse = getFetchResponse(error)
+  if (fetchResponse) {
+    return getErrorTextFromFetchResponse(fetchResponse, String(error))
+  }
+  if (isNuxtError(error)) {
+    return getErrorTextFromNuxtError(error, String(error))
+  }
+  return String(error)
+}
+
 export const snackbarForErrors = async ({ snackbar, error, defaultTitle }: Props) => {
   let title = defaultTitle ?? 'Error.'
   let text = `${error}`

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -164,8 +164,8 @@ def resolve_rfctobe(identifier: str) -> RfcToBe:
     When multiple RfcToBes share a draft name (e.g., one withdrawn and one
     in-progress), the non-withdrawn one is preferred.
     """
-    if identifier.lower().startswith("rfc") and identifier[3:].isdigit():
-        rfc_number = int(identifier[3:])
+    if identifier.lower().startswith("rfc") and identifier[3:].strip().isdigit():
+        rfc_number = int(identifier[3:].strip())
         qs = RfcToBe.objects.filter(rfc_number=rfc_number)
         obj = qs.exclude(disposition_id="withdrawn").first() or qs.first()
         if obj is None:
@@ -174,7 +174,7 @@ def resolve_rfctobe(identifier: str) -> RfcToBe:
     qs = RfcToBe.objects.filter(draft__name=identifier)
     obj = qs.exclude(disposition_id="withdrawn").first() or qs.first()
     if obj is None:
-        raise NotFound(f"No RfcToBe found for draft '{identifier}'")
+        raise NotFound(f"No record found for '{identifier}'")
     return obj
 
 
@@ -1082,12 +1082,8 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
 
     def get_object(self):
         lookup_value = self.kwargs.get(self.lookup_field)
-        if lookup_value and str(lookup_value).startswith("rfc"):
-            self.lookup_field = "rfc_number"
-            self.kwargs[self.lookup_field] = int(lookup_value[3:])
-        else:
-            self.kwargs["pk"] = resolve_rfctobe(lookup_value).pk
-            self.lookup_field = "pk"
+        self.kwargs["pk"] = resolve_rfctobe(lookup_value).pk
+        self.lookup_field = "pk"
         return super().get_object()
 
     def get_queryset(self):
@@ -1281,7 +1277,7 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
         cluster_number = None
         if query.isdigit():
             rfc_number = int(query)
-        elif query.lower().startswith("rfc") and query[3:].isdigit():
+        elif query.lower().startswith("rfc") and query[3:].strip().isdigit():
             rfc_number = int(query[3:])
         elif query.lower().startswith("c") and query[1:].isdigit():
             cluster_number = int(query[1:])


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/1154 and fixes https://github.com/ietf-tools/purple/issues/1161

make behavior consistent to find RfcToBe by identifier
now, both "rfc 1234" and "rfc1234" work, both in URL and via search
use existing resolver to avoid DRY

If error, show API response in error message in UI