### PR TITLE
feat: move cluster in same of already received ref

### DIFF
--- a/client/app/pages/docs/import.vue
+++ b/client/app/pages/docs/import.vue
@@ -133,6 +133,7 @@ import type { PaginatedDocumentCommentList, Name } from '~/purple_client'
 import { computed } from 'vue'
 import { type IANAActionsEnum } from '../../utils/iana'
 import { QUEUE_SUBMISSIONS_PATH } from '../../utils/url'
+import { snackbarForErrors } from '~/utils/snackbar'
 
 const route = useRoute()
 const api = useApi()
@@ -217,11 +218,7 @@ async function importSubmission () {
       }
     })
   } catch (e) {
-    snackbar.add({
-      type: 'error',
-      title: 'Error saving',
-      text: String(e)
-    })
+    snackbarForErrors({ snackbar, error: e, defaultTitle: 'Error saving' })
   }
   if (imported) {
     snackbar.add({

--- a/client/app/utils/document_relations-utils.ts
+++ b/client/app/utils/document_relations-utils.ts
@@ -185,15 +185,14 @@ const makeTooltip = (node: NodeParam): string[] | undefined => {
   } else if (node.isReceived === false) {
     tooltip.push('Not received.')
   }
-  if (node.disposition) {
+  if (node.isBlocked) {
+    tooltip.push('Blocked.')
+  } else if (node.disposition) {
     if (node.disposition === 'published') {
       tooltip.push('Published.')
     } else {
       tooltip.push(`Disposition: ${startCase(node.disposition)}.`)
     }
-  }
-  if (node.isBlocked) {
-    tooltip.push('Blocked.')
   }
   return tooltip.length > 0 ? tooltip : undefined
 }

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -191,44 +191,33 @@ def apply_submission_cluster_membership(
 ) -> Cluster | None:
     """Place imported document into an existing reference cluster or create a new one.
 
-    If any received reference is already clustered, the current document joins that
-    cluster. Otherwise, create a new cluster and add the current document and all
-    reference documents that are not already clustered. If there are no references,
-    received or not, do not create a cluster.
+    If either the current document or any of its references is already in a cluster,
+    all unclustered documents join that cluster. Otherwise a new cluster is created
+    and all documents are added to it. If there are no references (received or not),
+    no cluster is created.
     """
 
     if not reference_docs and not received_reference_ids and not has_not_received_refs:
         return None
 
+    all_docs = {current_doc.pk: current_doc}
+    for doc in reference_docs:
+        all_docs.setdefault(doc.pk, doc)
+
     existing_member = (
-        ClusterMember.objects.filter(doc__datatracker_id__in=received_reference_ids)
-        .select_related("cluster")
+        ClusterMember.objects.select_related("cluster")
+        .filter(doc_id__in=all_docs)
         .first()
     )
+
     if existing_member is not None:
-        add_doc_to_cluster(existing_member.cluster, current_doc)
+        for doc in all_docs.values():
+            add_doc_to_cluster(existing_member.cluster, doc)
         return existing_member.cluster
 
-    docs_by_id = {current_doc.id: current_doc}
-    for reference_doc in reference_docs:
-        docs_by_id.setdefault(reference_doc.id, reference_doc)
-
-    clustered_doc_ids = set(
-        ClusterMember.objects.filter(doc_id__in=docs_by_id).values_list(
-            "doc_id", flat=True
-        )
-    )
-    docs_to_add = [
-        doc for doc_id, doc in docs_by_id.items() if doc_id not in clustered_doc_ids
-    ]
-    if not docs_to_add:
-        return None
-
     cluster = create_cluster()
-
-    for doc in docs_to_add:
+    for doc in all_docs.values():
         add_doc_to_cluster(cluster, doc)
-
     return cluster
 
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1065,11 +1065,21 @@ class CreateRpcRelatedDocumentSerializer(RpcRelatedDocumentSerializer):
                 }
                 related_doc = super().create(data)
                 if should_add_to_cluster:
-                    cluster = self._get_or_create_source_cluster(source=source)
-                    self._add_target_document_to_cluster(
-                        cluster=cluster,
-                        target_document=target_cluster_document,
+                    target_member = (
+                        ClusterMember.objects.select_related("cluster")
+                        .filter(doc=target_cluster_document)
+                        .first()
                     )
+                    if target_member is not None:
+                        # Target is already in a cluster; source joins it.
+                        if source.draft:
+                            add_doc_to_cluster(target_member.cluster, source.draft)
+                    else:
+                        cluster = self._get_or_create_source_cluster(source=source)
+                        self._add_target_document_to_cluster(
+                            cluster=cluster,
+                            target_document=target_cluster_document,
+                        )
         except IntegrityError as err:
             raise serializers.ValidationError(
                 f"Failed to create related document due to a database constraint: {err}"

--- a/rpc/tests.py
+++ b/rpc/tests.py
@@ -205,6 +205,26 @@ class ApplySubmissionClusterMembershipTests(TestCase):
         doc_b.refresh_from_db()
         self.assertEqual(doc_b.clustermember_set.get().cluster, cluster_a)
 
+    def test_current_doc_already_clustered_reference_joins_it(self):
+        """If current doc is already in a cluster, unclustered references join it."""
+        doc_a = RfcToBeFactory().draft
+        cluster_a = apply_submission_cluster_membership(
+            current_doc=doc_a,
+            reference_docs=[],
+            received_reference_ids=set(),
+            has_not_received_refs=True,
+        )
+
+        doc_b = DocumentFactory(pages=1)
+        apply_submission_cluster_membership(
+            current_doc=doc_a,
+            reference_docs=[doc_b],
+            received_reference_ids={doc_b.datatracker_id},
+        )
+
+        doc_b.refresh_from_db()
+        self.assertEqual(doc_b.clustermember_set.get().cluster, cluster_a)
+
     def test_later_received_doc_creates_cluster_if_source_unclustered(self):
         """If A somehow has no cluster, importing B creates one for both."""
         doc_a = RfcToBeFactory().draft

--- a/rpc/utils.py
+++ b/rpc/utils.py
@@ -60,6 +60,7 @@ def create_cluster() -> Cluster:
         Value(1),
     )
     cluster = Cluster.objects.create(number=next_number)
+    # Refresh from DB to get the actual assigned number, not Coalesce expression
     cluster.refresh_from_db()
     return cluster
 

--- a/rpc/utils.py
+++ b/rpc/utils.py
@@ -59,7 +59,9 @@ def create_cluster() -> Cluster:
         ),
         Value(1),
     )
-    return Cluster.objects.create(number=next_number)
+    cluster = Cluster.objects.create(number=next_number)
+    cluster.refresh_from_db()
+    return cluster
 
 
 def add_doc_to_cluster(cluster: Cluster, doc: Document) -> None:


### PR DESCRIPTION
improve logic:
if a new draft is imported and either it is or it has a normative reference already in cluster, it should join the same cluster.
if either it is or it has a normative reference that is NOT yet in a cluster, the cluster shall be created and both should join the cluster

- display error in enqueuing in snackbar
- in cluster graph, show disposition only if not blocked
- add tests