### PR TITLE
fix: graph legend render

### DIFF
--- a/client/app/components/DocumentDependenciesGraph.vue
+++ b/client/app/components/DocumentDependenciesGraph.vue
@@ -44,7 +44,7 @@
       <h3 class="mt-4 font-bold">Cluster</h3>
       <pre>{{ JSON.stringify(clusterToUse, null, 2) }}</pre>
       <h3 class="mt-4 font-bold">RFCsToBe</h3>
-      <pre>{{ JSON.stringify(clusterToUse.documents?.flatMap(d => d.references ?? []), null, 2) }}</pre>
+      <pre>{{JSON.stringify(clusterToUse.documents?.flatMap(d => d.references ?? []), null, 2)}}</pre>
     </div>
   </details>
 </template>
@@ -222,14 +222,13 @@ const attemptToRenderGraph = () => {
     return
   }
 
-  const graphData = structuredClone(
+  const chosenGraphData: DrawGraphParameters[0]["data"] = structuredClone(
     // the D3 code will mutate arg data so we'll make a copy
-    clusterGraphData.value
+    // rendering bugs can be caused by not doing this
+    showLegend.value
+      ? legendData
+      : clusterGraphData.value
   )
-
-  const chosenGraphData: DrawGraphParameters[0]["data"] = showLegend.value
-    ? legendData
-    : graphData
 
   let [leg_el, leg_sim] = drawGraph({
     data: chosenGraphData,


### PR DESCRIPTION
## fix

* the graphing code (d3 and our custom code) seems to mutate the arg data which causes rendering glitches after displaying the legend multiple times. If you switch back and forth between legend and other you'll see the rendering goes weird with short arrows etc. The fix is to make a deep copy of the data we send in every time. 