### PR TITLE
fix: store datepicker dates as noon, display as UTC

### DIFF
--- a/client/app/components/DocInfoCard.vue
+++ b/client/app/components/DocInfoCard.vue
@@ -387,7 +387,7 @@
             <PatchRfcToBeField fieldName="externalDeadline" :is-read-only="props.isReadOnly"
               :ui-mode="{ type: 'date', initialValue: rfcToBe.externalDeadline ? jsDateToInputTypeDate(rfcToBe.externalDeadline) : undefined }"
               :draft-name="rfcToBe.name ?? ''" :on-success="props.refresh">
-              <span>{{ rfcToBe.externalDeadline ? DateTime.fromJSDate(rfcToBe.externalDeadline).toLocaleString(DateTime.DATE_FULL) : '(none)' }}</span>
+              <span>{{ rfcToBe.externalDeadline ? DateTime.fromJSDate(rfcToBe.externalDeadline, { zone: 'utc' }).toLocaleString(DateTime.DATE_FULL) : '(none)' }}</span>
             </PatchRfcToBeField>
           </DescriptionListDetails>
         </DescriptionListItem>

--- a/client/app/components/DocumentActionHolders.vue
+++ b/client/app/components/DocumentActionHolders.vue
@@ -123,7 +123,7 @@ const columns = [
       if (!date) {
         return '(N/A)'
       }
-      const dateTime = DateTime.fromJSDate(date)
+      const dateTime = DateTime.fromJSDate(date, { zone: 'utc' })
       return h('time', { datetime: dateTime.toString() }, dateTime.toLocaleString(
         DateTime.DATE_MED_WITH_WEEKDAY
       ))
@@ -136,7 +136,7 @@ const columns = [
     cell: data => {
       const completed = data.row.original.completed
       if (completed) {
-        const dateTime = DateTime.fromJSDate(completed)
+        const dateTime = DateTime.fromJSDate(completed, { zone: 'utc' })
         return h('div', { class: 'flex flex-row items-center gap-1' }, [
           h(Icon, { name: 'duo-icons:approved', size: '1.25em', class: 'text-green-500' }),
           h('time', { datetime: dateTime.toISO(), class: 'text-green-700 text-sm' },
@@ -154,7 +154,7 @@ const columns = [
     cell: data => {
       const date = data.getValue()
       if (!date) return h('span', { class: 'text-gray-400' }, '(none)')
-      const dateTime = DateTime.fromJSDate(date)
+      const dateTime = DateTime.fromJSDate(date, { zone: 'utc' })
       return h('time', { datetime: dateTime.toISO() }, dateTime.toLocaleString(DateTime.DATE_MED))
     },
     sortingFn: 'alphanumeric',

--- a/client/app/components/DocumentFinalReviews.vue
+++ b/client/app/components/DocumentFinalReviews.vue
@@ -158,7 +158,7 @@ const columns = [
   }),
   columnHelper.accessor(
     'approved', {
-    header: 'Date Approved / (N/A)',
+    header: 'Date Approved',
     cell: data => {
       const date = data.getValue()
       if (!date) {

--- a/client/app/components/DocumentFinalReviews.vue
+++ b/client/app/components/DocumentFinalReviews.vue
@@ -135,7 +135,7 @@ const columns = [
       if (!date) {
         return '(N/A)'
       }
-      const dateTime = DateTime.fromJSDate(date)
+      const dateTime = DateTime.fromJSDate(date, { zone: 'utc' })
       return h('time', { datetime: dateTime.toString() }, dateTime.toLocaleString(
         DateTime.DATE_MED_WITH_WEEKDAY
       ))
@@ -164,7 +164,7 @@ const columns = [
       if (!date) {
         return '(N/A)'
       }
-      const dateTime = DateTime.fromJSDate(date)
+      const dateTime = DateTime.fromJSDate(date, { zone: 'utc' })
       return h('time', { datetime: dateTime.toString() }, dateTime.toLocaleString(
         DateTime.DATE_MED_WITH_WEEKDAY
       ))

--- a/client/app/components/PatchRfcToBeField.vue
+++ b/client/app/components/PatchRfcToBeField.vue
@@ -87,6 +87,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { DateTime } from 'luxon'
+import { inputTypeDateToDateTime } from '~/utils/form'
 import type { RfcToBe, PatchedRfcToBeRequest } from '~/purple_client'
 import { snackbarForErrors } from '~/utils/snackbar'
 
@@ -162,7 +163,7 @@ const updateValue = async () => {
           draftName: props.draftName,
           patchedRfcToBeRequest: {
             [fieldName]: valueStringRef.value
-              ? DateTime.fromISO(valueStringRef.value, { zone: 'utc' }).toJSDate()
+              ? inputTypeDateToDateTime(valueStringRef.value).toJSDate()
               : null
           }
         })

--- a/client/app/pages/docs/[id]/assignments.vue
+++ b/client/app/pages/docs/[id]/assignments.vue
@@ -179,7 +179,7 @@ const rfcToBe = computed((): CookedDraft | null => {
       ...rawRfcToBe.value,
       externalDeadline:
         rawRfcToBe.value.externalDeadline
-          ? DateTime.fromJSDate(rawRfcToBe.value.externalDeadline)
+          ? DateTime.fromJSDate(rawRfcToBe.value.externalDeadline, { zone: 'utc' })
           : null
     }
   }

--- a/client/app/pages/docs/import.vue
+++ b/client/app/pages/docs/import.vue
@@ -134,6 +134,7 @@ import { computed } from 'vue'
 import { type IANAActionsEnum } from '../../utils/iana'
 import { QUEUE_SUBMISSIONS_PATH } from '../../utils/url'
 import { snackbarForErrors } from '~/utils/snackbar'
+import { inputTypeDateToDateTime } from '~/utils/form'
 
 const route = useRoute()
 const api = useApi()
@@ -212,7 +213,7 @@ async function importSubmission () {
         submittedFormat: state.sourceFormat.slug,
         stdLevel: state.stdLevel.slug,
         stream: state.stream.slug,
-        externalDeadline: DateTime.fromISO(state.deadline, { zone: 'utc' }).toJSDate(),
+        externalDeadline: inputTypeDateToDateTime(state.deadline).toJSDate(),
         labels: state.labels,
         ianaStatusSlug: state.ianaAction
       }

--- a/client/app/utils/form.ts
+++ b/client/app/utils/form.ts
@@ -26,5 +26,6 @@ export const hoursToDurationString = (hours: number): string => {
 
 export const jsDateToInputTypeDate = (date: Date): string => DateTime.fromJSDate(date, { zone: 'utc' }).toISODate() ?? ''
 
+// use 12:00 UTC to minimize date ambiguity across time zones
 export const inputTypeDateToDateTime = (isoDateString: string): DateTime => DateTime.fromISO(isoDateString, { zone: 'utc' }).set({ hour: 12 })
 

--- a/client/app/utils/form.ts
+++ b/client/app/utils/form.ts
@@ -24,7 +24,7 @@ export const hoursToDurationString = (hours: number): string => {
   return duration.toFormat('d hh:mm:ss')
 }
 
-export const jsDateToInputTypeDate = (date: Date): string => DateTime.fromJSDate(date).toISODate() ?? ''
+export const jsDateToInputTypeDate = (date: Date): string => DateTime.fromJSDate(date, { zone: 'utc' }).toISODate() ?? ''
 
-export const inputTypeDateToDateTime = (isoDateString: string): DateTime => DateTime.fromISO(isoDateString, { zone: 'utc' })
+export const inputTypeDateToDateTime = (isoDateString: string): DateTime => DateTime.fromISO(isoDateString, { zone: 'utc' }).set({ hour: 12 })
 


### PR DESCRIPTION
apply changes for fields
- external deadline (Rfc)
- approved / requested (Final Approval)
- deadline / completed (Action holder)