### PR TITLE
feat: add cache warming for DT persons

### DIFF
--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -75,10 +75,14 @@ class DatatrackerPerson(models.Model):
     @classmethod
     @with_rpcapi
     def warm_cache(cls, datatracker_ids: list[int], *, rpcapi: rpcapi_client.PurpleApi):
-        """Batch-fetch person data and populate the per-person cache.
+        """Batch-fetch person data from datatracker and populate the per-person cache.
 
-        Replaces N individual get_person_by_id() calls with one get_persons() call.
-        Call this before serializing many DatatrackerPerson objects.
+        Without this, _fetch() makes one API call per person per response. Because all
+        persons in a response are cached together, their entries also expire together,
+        causing N simultaneous API calls on the next cache miss.
+
+        Calling this before serialization replaces those N individual calls with a single
+        batch request. Only persons not already in cache are fetched.
         """
         no_value = object()
         missing = [

--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -81,8 +81,8 @@ class DatatrackerPerson(models.Model):
         persons in a response are cached together, their entries also expire together,
         causing N simultaneous API calls on the next cache miss.
 
-        Calling this before serialization replaces those N individual calls with a single
-        batch request. Only persons not already in cache are fetched.
+        Calling this before serialization replaces those N individual calls with a
+        single batch request. Only persons not already in cache are fetched.
         """
         no_value = object()
         missing = [

--- a/datatracker/models.py
+++ b/datatracker/models.py
@@ -72,6 +72,32 @@ class DatatrackerPerson(models.Model):
             url = build_datatracker_url(url)
         return url
 
+    @classmethod
+    @with_rpcapi
+    def warm_cache(cls, datatracker_ids: list[int], *, rpcapi: rpcapi_client.PurpleApi):
+        """Batch-fetch person data and populate the per-person cache.
+
+        Replaces N individual get_person_by_id() calls with one get_persons() call.
+        Call this before serializing many DatatrackerPerson objects.
+        """
+        no_value = object()
+        missing = [
+            i
+            for i in datatracker_ids
+            if cache.get(f"datatracker_person-{i}", no_value) is no_value
+        ]
+        if not missing:
+            return
+        try:
+            for person in rpcapi.get_persons(missing):
+                cache.set(f"datatracker_person-{person.id}", person.json())
+        except (
+            urllib3.exceptions.MaxRetryError,
+            urllib3.exceptions.NewConnectionError,
+            rpcapi_client.exceptions.ApiException,
+        ):
+            pass  # Individual _fetch() calls will handle errors on their own
+
     @with_rpcapi
     def _fetch(self, field_name, *, rpcapi: rpcapi_client.PurpleApi):
         """Get field_name value for person (uses cache)"""

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -18,7 +18,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Cluster'
+                  $ref: '#/components/schemas/PublicCluster'
           description: ''
   /api/pubq/clusters/{number}/:
     get:
@@ -40,7 +40,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Cluster'
+                $ref: '#/components/schemas/PublicCluster'
           description: ''
   /api/pubq/queue/:
     get:
@@ -4967,6 +4967,78 @@ components:
       required:
       - rfc_to_be
       - role
+    PublicCluster:
+      type: object
+      description: |-
+        Serialize a Cluster instance
+
+        Uses a nested representation for `documents` rather than the ModelSerializer's
+        handling of relations so we can work with the through model. Specifically, we
+        want to respect the `order_by` setting of the `ClusterMember` class.
+      properties:
+        number:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicClusterMember'
+          readOnly: true
+        is_active:
+          type: boolean
+          description: |-
+            A cluster is considered active if at least one of its documents is
+            in_progress.
+          readOnly: true
+      required:
+      - number
+    PublicClusterMember:
+      type: object
+      properties:
+        name:
+          type: string
+        rfc_number:
+          type: integer
+          nullable: true
+          readOnly: true
+        disposition:
+          type: string
+          nullable: true
+          readOnly: true
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/RpcRelatedDocument'
+          readOnly: true
+        is_received:
+          type: boolean
+          nullable: true
+          description: Determine if the document has been received based on related
+            documents
+          readOnly: true
+        is_normref:
+          type: boolean
+          description: |-
+            True if this document is a normative reference target of any other
+            cluster member in same cluster.
+
+            Uses the pre-computed set from ClusterMemberListSerializer.to_representation
+            when available, falling back to a direct lookup.
+          readOnly: true
+        order:
+          type: integer
+        is_blocked:
+          type: boolean
+          readOnly: true
+        final_approval_counts:
+          allOf:
+          - $ref: '#/components/schemas/FinalApprovalCounts'
+          nullable: true
+          readOnly: true
+      required:
+      - name
+      - order
     PublicQueueAuthor:
       type: object
       properties:

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -750,6 +750,21 @@ class QueueCounts(views.APIView):
         return Response(data)
 
 
+def _collect_queue_person_ids(items) -> list[int]:
+    """Collect all DatatrackerPerson IDs from action holders and final approvals."""
+    ids: set[int] = set()
+    for item in items:
+        for ah in item.active_actionholders:
+            if ah.datatracker_person_id is not None:
+                ids.add(ah.datatracker_person.datatracker_id)
+        for fa in item.finalapproval_set.all():
+            if fa.approver_id is not None:
+                ids.add(fa.approver.datatracker_id)
+            if fa.overriding_approver_id is not None:
+                ids.add(fa.overriding_approver.datatracker_id)
+    return list(ids)
+
+
 class QueueList(ListAPIView):
     """Queue view for purple application"""
 
@@ -761,10 +776,21 @@ class QueueList(ListAPIView):
         .with_active_assignments()
         .with_active_actionholders()
         .with_blocking_reasons()
+        .with_final_approvals()
     )
     serializer_class = QueueItemSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = QueueFilter
+
+    def list(self, request, *args, **kwargs):
+        queryset = list(self.filter_queryset(self.get_queryset()))
+        DatatrackerPerson.warm_cache(_collect_queue_person_ids(queryset))
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 QueueList = extend_schema_view(
@@ -1075,6 +1101,20 @@ class RfcToBeQueryParamsForm(forms.Form):
     published_within_days = forms.IntegerField(required=False, min_value=0)
 
 
+def _collect_document_person_ids(items) -> list[int]:
+    """Collect all DatatrackerPerson IDs from authors, shepherd, IESG contact, and
+    stream manager."""
+    ids: set[int] = set()
+    for item in items:
+        for author in item.authors.all():
+            if author.datatracker_person_id is not None:
+                ids.add(author.datatracker_person.datatracker_id)
+        for person in (item.iesg_contact, item.shepherd, item.stream_manager):
+            if person is not None:
+                ids.add(person.datatracker_id)
+    return list(ids)
+
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -1097,7 +1137,12 @@ class RfcToBeQueryParamsForm(forms.Form):
     ),
 )
 class RfcToBeViewSet(viewsets.ModelViewSet):
-    queryset = RfcToBe.objects.all().with_blocking_reasons()
+    queryset = (
+        RfcToBe.objects.all()
+        .select_related("iesg_contact", "shepherd", "stream_manager")
+        .with_blocking_reasons()
+        .with_authors()
+    )
     serializer_class = RfcToBeSerializer
     lookup_field = "draft__name"
     filter_backends = (
@@ -1108,6 +1153,24 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
     ordering_fields = ["id", "published_at", "draft__name"]
     ordering = ["-id"]
     pagination_class = DefaultLimitOffsetPagination
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            DatatrackerPerson.warm_cache(_collect_document_person_ids(page))
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        items = list(queryset)
+        DatatrackerPerson.warm_cache(_collect_document_person_ids(items))
+        serializer = self.get_serializer(items, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        DatatrackerPerson.warm_cache(_collect_document_person_ids([instance]))
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
 
     def get_object(self):
         lookup_value = self.kwargs.get(self.lookup_field)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -117,6 +117,7 @@ from .serializers import (
     MetadataValidationResultsSerializer,
     NameSerializer,
     NestedAssignmentSerializer,
+    PublicClusterSerializer,
     PublicQueueItemSerializer,
     PublishRfcSerializer,
     PublishRfcStatusSerializer,
@@ -832,7 +833,7 @@ class PublicClusterViewSet(viewsets.ReadOnlyModelViewSet):
         .filter(is_active_annotated=True)
         .order_by("number")
     )
-    serializer_class = ClusterSerializer
+    serializer_class = PublicClusterSerializer
     lookup_field = "number"
 
 

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -163,6 +163,26 @@ class RfcToBeQuerySet(models.QuerySet):
             )
         )
 
+    def with_final_approvals(self):
+        return self.prefetch_related(
+            Prefetch(
+                "finalapproval_set",
+                queryset=FinalApproval.objects.select_related(
+                    "approver", "overriding_approver"
+                ),
+            )
+        )
+
+    def with_authors(self):
+        return self.prefetch_related(
+            Prefetch(
+                "authors",
+                queryset=RfcAuthor.objects.select_related(
+                    "datatracker_person"
+                ).order_by("order"),
+            )
+        )
+
 
 class RfcToBe(models.Model):
     """RPC representation of a pre-publication RFC"""

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1162,6 +1162,45 @@ class FinalApprovalCountsSerializer(serializers.Serializer):
     total = serializers.IntegerField()
 
 
+class NotReceivedClusterMemberSerializer(serializers.Serializer):
+    """ClusterMember shape for documents referenced but not yet received
+    into the queue."""
+
+    name = serializers.CharField()
+    rfc_number = serializers.SerializerMethodField()
+    disposition = serializers.SerializerMethodField()
+    references = serializers.SerializerMethodField()
+    is_received = serializers.SerializerMethodField()
+    is_normref = serializers.SerializerMethodField()
+    order = serializers.SerializerMethodField()
+    is_blocked = serializers.SerializerMethodField()
+    final_approval_counts = serializers.SerializerMethodField()
+
+    def get_rfc_number(self, obj):
+        return None
+
+    def get_disposition(self, obj):
+        return None
+
+    def get_references(self, obj):
+        return None
+
+    def get_is_received(self, obj):
+        return False
+
+    def get_is_normref(self, obj):
+        return True
+
+    def get_order(self, obj):
+        return None
+
+    def get_is_blocked(self, obj):
+        return False
+
+    def get_final_approval_counts(self, obj):
+        return None
+
+
 class ClusterMemberListSerializer(serializers.ListSerializer):
     """ListSerializer for ClusterMembers to allow multiple updates
 
@@ -1487,6 +1526,61 @@ class ClusterSerializer(serializers.ModelSerializer):
 
         instance.refresh_from_db()
         return instance
+
+
+class PublicClusterMemberListSerializer(ClusterMemberListSerializer):
+    """Extends ClusterMemberListSerializer to append not-received referenced docs."""
+
+    def to_representation(self, data):
+        items = data.all() if hasattr(data, "all") else data
+        existing_names: set[str] = {member.doc.name for member in items}
+        not_received_targets: dict[str, Document] = {}
+        for member in items:
+            if (
+                hasattr(member.doc, "rfctobe_annotated")
+                and member.doc.rfctobe_annotated
+            ):
+                refs = (
+                    getattr(
+                        member.doc.rfctobe_annotated[0], "references_annotated", None
+                    )
+                    or []
+                )
+            else:
+                rfctobe = member.doc.rfctobe_set.exclude(
+                    disposition__slug="withdrawn"
+                ).first()
+                refs = (
+                    RpcRelatedDocument.objects.filter(
+                        source=rfctobe,
+                        relationship__slug=DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG,
+                    ).select_related("target_document")
+                    if rfctobe
+                    else []
+                )
+            for ref in refs:
+                if (
+                    ref.relationship.slug
+                    == DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG
+                    and ref.target_document
+                    and ref.target_document.name not in existing_names
+                ):
+                    not_received_targets[ref.target_document.name] = ref.target_document
+        result = list(super().to_representation(data))
+        for doc in not_received_targets.values():
+            result.append(NotReceivedClusterMemberSerializer(doc).data)
+        return result
+
+
+class PublicClusterMemberSerializer(ClusterMemberSerializer):
+    class Meta(ClusterMemberSerializer.Meta):
+        list_serializer_class = PublicClusterMemberListSerializer
+
+
+class PublicClusterSerializer(ClusterSerializer):
+    documents = PublicClusterMemberSerializer(
+        source="clustermember_set", many=True, read_only=True
+    )
 
 
 class ClusterMemberHistorySerializer(serializers.Serializer):


### PR DESCRIPTION
current behavior: we call DT person names for each DT person that comes up in a API response.
We do cache those... but since we populate usually all of them at the same time, they will be invalidated from cache all at the same time and N calls have to be done to refresh the cache.

Better approach: use a batch endpoint, and populate cache before the API response is processed.

