### PR TITLE
feat: show number of records in each tabs

### DIFF
--- a/client/app/components/QueueTabs.vue
+++ b/client/app/components/QueueTabs.vue
@@ -1,16 +1,42 @@
 <template>
   <div class="flex justify-center items-center">
-    <TabNav :tabs="queueTabs" :selected="props.currentTab" />
+    <TabNav :tabs="tabs" :selected="props.currentTab" />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { QueueTabId } from '../utils/queue'
 import { queueTabs } from '~/utils/queue'
+import type { Tab } from '~/utils/tab'
+import type { QueueCounts } from '~/purple_client'
 
 type Props = {
   currentTab: QueueTabId
 }
 
 const props = defineProps<Props>()
+
+const api = useApi()
+const route = useRoute()
+
+const { data: counts } = await useAsyncData(
+  'queue-tab-counts',
+  () => api.queueCounts(),
+  {
+    server: false,
+    lazy: true,
+    watch: [route],
+    default: (): Partial<QueueCounts> => ({}),
+  }
+)
+
+const tabs = computed<Tab[]>(() =>
+  queueTabs.map(tab => {
+    const countKey = tab.id.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) as keyof QueueCounts
+    return {
+      ...tab,
+      count: counts.value[countKey] ?? null,
+    }
+  })
+)
 </script>

--- a/client/app/components/QueueTabs.vue
+++ b/client/app/components/QueueTabs.vue
@@ -32,6 +32,8 @@ const { data: counts } = await useAsyncData(
 
 const tabs = computed<Tab[]>(() =>
   queueTabs.map(tab => {
+    // map tab id to the corresponding count key
+    // e.g. "pending-announcement" → "pendingAnnouncement"
     const countKey = tab.id.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) as keyof QueueCounts
     return {
       ...tab,

--- a/client/app/components/TabNav.vue
+++ b/client/app/components/TabNav.vue
@@ -24,6 +24,7 @@
         aria-hidden="true"
       />
       <span>{{ tab.name }}</span>
+      <span v-if="tab.count != null" class="ml-1 text-xs opacity-60">({{ tab.count }})</span>
       <span
         aria-hidden="true"
         :class="[

--- a/client/app/components/TabNavTypes.ts
+++ b/client/app/components/TabNavTypes.ts
@@ -4,4 +4,5 @@ export type Tab = {
   to: string
   icon: string
   iconAnimate?: boolean
+  count?: number | null
 }

--- a/client/app/pages/queue/enqueuing.vue
+++ b/client/app/pages/queue/enqueuing.vue
@@ -9,6 +9,13 @@
       {{ error }}
     </ErrorAlert>
 
+    <div class="flex justify-between items-center mb-2">
+      <div></div>
+      <div class="text-sm text-gray-500 dark:text-neutral-400">
+        {{ table.getRowModel().rows.length }} records
+      </div>
+    </div>
+
     <div class="p-2">
       <RpcTable>
         <RpcThead>

--- a/client/app/pages/queue/pending-announcement.vue
+++ b/client/app/pages/queue/pending-announcement.vue
@@ -9,6 +9,13 @@
       {{ error }}
     </ErrorAlert>
 
+    <div class="flex justify-between items-center mb-2">
+      <div></div>
+      <div class="text-sm text-gray-500 dark:text-neutral-400">
+        {{ table.getRowModel().rows.length }} records
+      </div>
+    </div>
+
     <div class="p-2">
       <RpcTable>
         <RpcThead>

--- a/client/app/pages/queue/published.vue
+++ b/client/app/pages/queue/published.vue
@@ -9,6 +9,13 @@
       {{ error }}
     </ErrorAlert>
 
+    <div class="flex justify-between items-center mb-2">
+      <div></div>
+      <div class="text-sm text-gray-500 dark:text-neutral-400">
+        {{ table.getRowModel().rows.length }} records
+      </div>
+    </div>
+
     <div class="p-2">
       <RpcTable>
         <RpcThead>
@@ -118,11 +125,6 @@ const columns = [
       ])
     },
     sortingFn: 'alphanumeric',
-  }),
-  columnHelper.display({
-    id: 'labels',
-    header: 'Labels',
-    cell: _data => '',
   }),
   columnHelper.display({
     id: 'owner', // FIXME: this doesn't exist yet

--- a/client/app/pages/queue/queue.vue
+++ b/client/app/pages/queue/queue.vue
@@ -79,6 +79,7 @@
       </div>
     </div>
 
+    <div class="p-2">
     <RpcTable>
       <RpcThead>
         <tr v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
@@ -111,6 +112,7 @@
         </tr>
       </RpcTfoot>
     </RpcTable>
+    </div>
   </div>
 
 

--- a/client/app/pages/queue/submissions.vue
+++ b/client/app/pages/queue/submissions.vue
@@ -5,6 +5,17 @@
 
     <QueueTabs :current-tab="currentTab" />
 
+    <ErrorAlert v-if="error">
+      {{ error }}
+    </ErrorAlert>
+
+    <div class="flex justify-between items-center mb-2">
+      <div></div>
+      <div class="text-sm text-gray-500 dark:text-neutral-400">
+        {{ table.getRowModel().rows.length }} records
+      </div>
+    </div>
+
     <div class="p-2">
       <RpcTable>
         <RpcThead>

--- a/purple/urls.py
+++ b/purple/urls.py
@@ -130,6 +130,7 @@ urlpatterns = [
     path("oidc/", include("mozilla_django_oidc.urls")),
     path("login/", views.index),
     path("api/pubq/queue/", rpc_api.PublicQueueList.as_view()),
+    path("api/rpc/queue/counts/", rpc_api.QueueCounts.as_view()),
     path("api/rpc/queue/", rpc_api.QueueList.as_view()),
     path(
         "api/rpc/search/datatrackerpersons/", rpc_api.SearchDatatrackerPersons.as_view()

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -2611,6 +2611,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/QueueItem'
           description: ''
+  /api/rpc/queue/counts/:
+    get:
+      operationId: queue_counts
+      description: Item counts for each queue tab
+      tags:
+      - purple
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueCounts'
+          description: ''
   /api/rpc/rpc_person/:
     get:
       operationId: rpc_person_list
@@ -5116,6 +5131,27 @@ components:
           type: string
         repository:
           type: string
+    QueueCounts:
+      type: object
+      description: Counts of items for each queue tab
+      properties:
+        submissions:
+          type: integer
+          nullable: true
+        enqueuing:
+          type: integer
+        queue:
+          type: integer
+        pending_announcement:
+          type: integer
+        published:
+          type: integer
+      required:
+      - enqueuing
+      - pending_announcement
+      - published
+      - queue
+      - submissions
     QueueItem:
       type: object
       description: RfcToBe serializer suitable for displaying a queue of many

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -44,7 +44,7 @@ from rest_framework.response import Response
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
 from datatracker.models import DatatrackerPerson, Document
-from datatracker.rpcapi import datatracker_api, with_rpcapi
+from datatracker.rpcapi import datatracker_api, get_rpcapi_client, with_rpcapi
 from utils.rest_framework.permissions import HasApiKey
 
 from .dt_v1_api_utils import datatracker_group_list_email
@@ -120,6 +120,7 @@ from .serializers import (
     PublicQueueItemSerializer,
     PublishRfcSerializer,
     PublishRfcStatusSerializer,
+    QueueCountsSerializer,
     QueueItemSerializer,
     RfcAuthorSerializer,
     RfcToBeHistorySerializer,
@@ -693,6 +694,59 @@ class QueueFilter(django_filters.FilterSet):
     class Meta:
         model = RfcToBe
         fields = ["disposition", "pending_final_approval"]
+
+
+@extend_schema(operation_id="queue_counts", responses={200: QueueCountsSerializer})
+class QueueCounts(views.APIView):
+    """Item counts for each queue tab"""
+
+    CACHE_KEY = "queue_counts"
+    CACHE_TTL = 60  # seconds
+
+    def get(self, request):
+        cached = cache.get(self.CACHE_KEY)
+        if cached is not None:
+            return Response(cached)
+
+        enqueuing = RfcToBe.objects.filter(disposition__slug="created").count()
+        queue = RfcToBe.objects.filter(disposition__slug="in_progress").count()
+        days_ago = datetime.date.today() - datetime.timedelta(days=30)
+        published = RfcToBe.objects.filter(
+            disposition__slug="published", published_at__gte=days_ago
+        ).count()
+        pending_announcement = (
+            RfcToBe.objects.in_queue()
+            .filter(finalapproval__isnull=False)
+            .exclude(finalapproval__approved__isnull=True)
+            .filter(assignment__role__slug="publisher")
+            .exclude(assignment__state__in=ASSIGNMENT_INACTIVE_STATES)
+            .distinct()
+            .count()
+        )
+        try:
+            rpcapi = get_rpcapi_client()
+            with datatracker_api():
+                submitted = rpcapi.submitted_to_rpc()
+            already_in_queue = set(
+                RfcToBe.objects.filter(
+                    draft__datatracker_id__in=[s.id for s in submitted]
+                ).values_list("draft__datatracker_id", flat=True)
+            )
+            submissions = sum(1 for s in submitted if s.id not in already_in_queue)
+        except Exception:
+            submissions = None
+
+        data = QueueCountsSerializer(
+            {
+                "submissions": submissions,
+                "enqueuing": enqueuing,
+                "queue": queue,
+                "pending_announcement": pending_announcement,
+                "published": published,
+            }
+        ).data
+        cache.set(self.CACHE_KEY, data, self.CACHE_TTL)
+        return Response(data)
 
 
 class QueueList(ListAPIView):

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -63,6 +63,16 @@ class VersionInfoSerializer(serializers.Serializer):
     dump_timestamp = serializers.DateTimeField(required=False, read_only=True)
 
 
+class QueueCountsSerializer(serializers.Serializer):
+    """Counts of items for each queue tab"""
+
+    submissions = serializers.IntegerField(allow_null=True)
+    enqueuing = serializers.IntegerField()
+    queue = serializers.IntegerField()
+    pending_announcement = serializers.IntegerField()
+    published = serializers.IntegerField()
+
+
 class NameSerializer(serializers.Serializer):
     """Serialize any Name subclass"""
 


### PR DESCRIPTION
resolve https://github.com/ietf-tools/purple/issues/969

- add new endpoint that returns number of records in each tab
- use caching 
- update whenever you navigate tab
- streamline tables in each tab (show number of records in each)

<img width="1205" height="196" alt="image" src="https://github.com/user-attachments/assets/17cfa387-44ab-42c0-9c7b-a5906fc54bbf" />

