### PR TITLE
feat: add not-received in list of cluster docs

### DIFF
--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -18,7 +18,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Cluster'
+                  $ref: '#/components/schemas/PublicCluster'
           description: ''
   /api/pubq/clusters/{number}/:
     get:
@@ -40,7 +40,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Cluster'
+                $ref: '#/components/schemas/PublicCluster'
           description: ''
   /api/pubq/queue/:
     get:
@@ -4967,6 +4967,78 @@ components:
       required:
       - rfc_to_be
       - role
+    PublicCluster:
+      type: object
+      description: |-
+        Serialize a Cluster instance
+
+        Uses a nested representation for `documents` rather than the ModelSerializer's
+        handling of relations so we can work with the through model. Specifically, we
+        want to respect the `order_by` setting of the `ClusterMember` class.
+      properties:
+        number:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicClusterMember'
+          readOnly: true
+        is_active:
+          type: boolean
+          description: |-
+            A cluster is considered active if at least one of its documents is
+            in_progress.
+          readOnly: true
+      required:
+      - number
+    PublicClusterMember:
+      type: object
+      properties:
+        name:
+          type: string
+        rfc_number:
+          type: integer
+          nullable: true
+          readOnly: true
+        disposition:
+          type: string
+          nullable: true
+          readOnly: true
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/RpcRelatedDocument'
+          readOnly: true
+        is_received:
+          type: boolean
+          nullable: true
+          description: Determine if the document has been received based on related
+            documents
+          readOnly: true
+        is_normref:
+          type: boolean
+          description: |-
+            True if this document is a normative reference target of any other
+            cluster member in same cluster.
+
+            Uses the pre-computed set from ClusterMemberListSerializer.to_representation
+            when available, falling back to a direct lookup.
+          readOnly: true
+        order:
+          type: integer
+        is_blocked:
+          type: boolean
+          readOnly: true
+        final_approval_counts:
+          allOf:
+          - $ref: '#/components/schemas/FinalApprovalCounts'
+          nullable: true
+          readOnly: true
+      required:
+      - name
+      - order
     PublicQueueAuthor:
       type: object
       properties:

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -117,6 +117,7 @@ from .serializers import (
     MetadataValidationResultsSerializer,
     NameSerializer,
     NestedAssignmentSerializer,
+    PublicClusterSerializer,
     PublicQueueItemSerializer,
     PublishRfcSerializer,
     PublishRfcStatusSerializer,
@@ -832,7 +833,7 @@ class PublicClusterViewSet(viewsets.ReadOnlyModelViewSet):
         .filter(is_active_annotated=True)
         .order_by("number")
     )
-    serializer_class = ClusterSerializer
+    serializer_class = PublicClusterSerializer
     lookup_field = "number"
 
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -1162,6 +1162,45 @@ class FinalApprovalCountsSerializer(serializers.Serializer):
     total = serializers.IntegerField()
 
 
+class NotReceivedClusterMemberSerializer(serializers.Serializer):
+    """ClusterMember shape for documents referenced but not yet received
+    into the queue."""
+
+    name = serializers.CharField()
+    rfc_number = serializers.SerializerMethodField()
+    disposition = serializers.SerializerMethodField()
+    references = serializers.SerializerMethodField()
+    is_received = serializers.SerializerMethodField()
+    is_normref = serializers.SerializerMethodField()
+    order = serializers.SerializerMethodField()
+    is_blocked = serializers.SerializerMethodField()
+    final_approval_counts = serializers.SerializerMethodField()
+
+    def get_rfc_number(self, obj):
+        return None
+
+    def get_disposition(self, obj):
+        return None
+
+    def get_references(self, obj):
+        return None
+
+    def get_is_received(self, obj):
+        return False
+
+    def get_is_normref(self, obj):
+        return True
+
+    def get_order(self, obj):
+        return None
+
+    def get_is_blocked(self, obj):
+        return False
+
+    def get_final_approval_counts(self, obj):
+        return None
+
+
 class ClusterMemberListSerializer(serializers.ListSerializer):
     """ListSerializer for ClusterMembers to allow multiple updates
 
@@ -1487,6 +1526,61 @@ class ClusterSerializer(serializers.ModelSerializer):
 
         instance.refresh_from_db()
         return instance
+
+
+class PublicClusterMemberListSerializer(ClusterMemberListSerializer):
+    """Extends ClusterMemberListSerializer to append not-received referenced docs."""
+
+    def to_representation(self, data):
+        items = data.all() if hasattr(data, "all") else data
+        existing_names: set[str] = {member.doc.name for member in items}
+        not_received_targets: dict[str, Document] = {}
+        for member in items:
+            if (
+                hasattr(member.doc, "rfctobe_annotated")
+                and member.doc.rfctobe_annotated
+            ):
+                refs = (
+                    getattr(
+                        member.doc.rfctobe_annotated[0], "references_annotated", None
+                    )
+                    or []
+                )
+            else:
+                rfctobe = member.doc.rfctobe_set.exclude(
+                    disposition__slug="withdrawn"
+                ).first()
+                refs = (
+                    RpcRelatedDocument.objects.filter(
+                        source=rfctobe,
+                        relationship__slug=DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG,
+                    ).select_related("target_document")
+                    if rfctobe
+                    else []
+                )
+            for ref in refs:
+                if (
+                    ref.relationship.slug
+                    == DocRelationshipName.NOT_RECEIVED_RELATIONSHIP_SLUG
+                    and ref.target_document
+                    and ref.target_document.name not in existing_names
+                ):
+                    not_received_targets[ref.target_document.name] = ref.target_document
+        result = list(super().to_representation(data))
+        for doc in not_received_targets.values():
+            result.append(NotReceivedClusterMemberSerializer(doc).data)
+        return result
+
+
+class PublicClusterMemberSerializer(ClusterMemberSerializer):
+    class Meta(ClusterMemberSerializer.Meta):
+        list_serializer_class = PublicClusterMemberListSerializer
+
+
+class PublicClusterSerializer(ClusterSerializer):
+    documents = PublicClusterMemberSerializer(
+        source="clustermember_set", many=True, read_only=True
+    )
 
 
 class ClusterMemberHistorySerializer(serializers.Serializer):


### PR DESCRIPTION
this changes should fix https://github.com/ietf-tools/queue/issues/58 and make queue cluster page work as it is.

Reasoning: `not-received` docs are not stored as ClusterMembers. However they should appear like cluster members on the queue site.
Solution: custom PublicClusterMemberSerializer that will add those `not-received` on-the-fly to the list as if they were full ClusterMembers