### PR TITLE
fix: glitch when Github call gets hash but download fails

### DIFF
--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -444,8 +444,8 @@ const fetchAndVerifyMetadata = async () => {
     step.value = {
       type: 'error',
       errorText: `Failed to validate metadata. Request status was still
-      ${JSON.stringify(resultsCreate.status)} after ${MAXIMUM_ATTEMPTS_DURATION_MS / 1000} seconds
-      and ${attemptCount} attempts.`,
+      ${JSON.stringify(resultsCreate.status)} after ${MAXIMUM_ATTEMPTS_DURATION_MS / 1000}
+      seconds.`,
       showResyncButton: true
     }
     return

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -271,7 +271,7 @@ const { data: rfcToBe, error: rfcToBeError, status: rfcToBeStatus, refresh: rfcT
   }
 )
 
-const { data: metadataValidationResults, error: metadataValidationResultsError, status: metadataValidationResultsStatus } = await useAsyncData(
+const { data: metadataValidationResults, error: metadataValidationResultsError, status: metadataValidationResultsStatus, refresh: metadataValidationResultsRefresh } = await useAsyncData(
   () => `draft-${draftName.value}-metadata-validation-results`,
   () => api.documentsMetadataValidationResultsList({
     draftName: draftName.value,
@@ -456,10 +456,17 @@ const fetchAndVerifyMetadata = async () => {
 
 const deleteMetadataValidationAndRetry = async (headSha: string) => {
   step.value = { type: 'loading' }
+  // Refresh to get the current head_sha — the stored one may be stale if the
+  // validation task ran and set a head_sha after the page was first loaded.
+  await metadataValidationResultsRefresh()
+  const currentResult = metadataValidationResults.value as unknown
+  const currentHeadSha = isMetadataValidationResults(currentResult)
+    ? currentResult.headSha!
+    : headSha
   try {
     await api.metadataValidationResultsDelete({
       draftName: draftName.value,
-      headSha,
+      headSha: currentHeadSha,
     })
   } catch (error: unknown) {
     snackbarForErrors({ snackbar, error, defaultTitle: "Couldn't delete validation results" })

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -316,11 +316,11 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
   if (
     rfcToBeStatus.value === 'error'
   ) {
-    let precomputedResult = metadataValidationResults.value as unknown
+    const precomputedResult = metadataValidationResults.value?.[0]
     step.value = {
       type: 'error',
       errorText: `Unable to load RFC ${draftName.value}. Server error: ${rfcToBeError.value?.message ?? ''} ${metadataValidationResultsError.value ?? ''}`,
-      showDeleteAndRetryButton: isMetadataValidationResults(precomputedResult) ? { headSha: precomputedResult.headSha! } : undefined,
+      showDeleteAndRetryButton: precomputedResult?.headSha ? { headSha: precomputedResult.headSha } : undefined,
       showResyncButton: true
     }
     return
@@ -458,13 +458,9 @@ const fetchAndVerifyMetadata = async () => {
 
 const deleteMetadataValidationAndRetry = async (headSha: string) => {
   step.value = { type: 'loading' }
-  // Refresh to get the current head_sha — the stored one may be stale if the
-  // validation task ran and set a head_sha after the page was first loaded.
+  // Refresh first — the stored head_sha may be stale if the task ran after page load.
   await metadataValidationResultsRefresh()
-  const currentResult = metadataValidationResults.value as unknown
-  const currentHeadSha = isMetadataValidationResults(currentResult) && currentResult.headSha
-    ? currentResult.headSha
-    : headSha
+  const currentHeadSha = metadataValidationResults.value?.[0]?.headSha || headSha
   try {
     await api.metadataValidationResultsDelete({
       draftName: draftName.value,

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -462,8 +462,8 @@ const deleteMetadataValidationAndRetry = async (headSha: string) => {
   // validation task ran and set a head_sha after the page was first loaded.
   await metadataValidationResultsRefresh()
   const currentResult = metadataValidationResults.value as unknown
-  const currentHeadSha = isMetadataValidationResults(currentResult)
-    ? currentResult.headSha!
+  const currentHeadSha = isMetadataValidationResults(currentResult) && currentResult.headSha
+    ? currentResult.headSha
     : headSha
   try {
     await api.metadataValidationResultsDelete({

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -46,7 +46,7 @@
         <div :class="step.showDeleteAndRetryButton ? 'flex justify-between' : 'text-center'">
           <BaseButton v-if="step.showDeleteAndRetryButton" btn-type="outline"
             @click="deleteMetadataValidationAndRetry(step.showDeleteAndRetryButton.headSha)">
-            Delete and re-fetch from repo
+            Re-fetch and validate again
           </BaseButton>
           <BaseButton v-if="step.showResyncButton" btn-type="default" @click="fetchAndVerifyMetadata" class="ml-2">
             Try again
@@ -340,6 +340,7 @@ watch([rfcToBe, rfcToBeStatus, metadataValidationResultsStatus, publicationStatu
         setTimeout(publicationStatusRefresh, PUBLICATION_STATUS_POLL_INTERVAL_MS)
         return
       case 'failed':
+        snackbar.add({ type: 'error', title: 'Publication failed', text: publicationStatus.value.detail })
         step.value = {
           type: 'publicationFailed',
           errorText: publicationStatus.value.detail,
@@ -429,7 +430,7 @@ const fetchAndVerifyMetadata = async () => {
     step.value = {
       type: 'error',
       errorText: `Couldn't start/poll for metadata sync results. Error: ${error}`,
-      showDeleteAndRetryButton: resultsCreate ? { headSha: resultsCreate.headSha! } : undefined,
+      showDeleteAndRetryButton: resultsCreate?.headSha ? { headSha: resultsCreate.headSha } : undefined,
       showResyncButton: true
     }
     if (!resultsCreate) {

--- a/client/app/pages/docs/[id]/publication-preparation.vue
+++ b/client/app/pages/docs/[id]/publication-preparation.vue
@@ -46,7 +46,7 @@
         <div :class="step.showDeleteAndRetryButton ? 'flex justify-between' : 'text-center'">
           <BaseButton v-if="step.showDeleteAndRetryButton" btn-type="outline"
             @click="deleteMetadataValidationAndRetry(step.showDeleteAndRetryButton.headSha)">
-            Retry metadata validation
+            Delete and re-fetch from repo
           </BaseButton>
           <BaseButton v-if="step.showResyncButton" btn-type="default" @click="fetchAndVerifyMetadata" class="ml-2">
             Try again
@@ -442,7 +442,9 @@ const fetchAndVerifyMetadata = async () => {
   if (resultsCreate.status !== 'success' && resultsCreate.status !== 'failed') {
     step.value = {
       type: 'error',
-      errorText: `Failed to validate metadata. Request status was still ${JSON.stringify(resultsCreate.status)}.`,
+      errorText: `Failed to validate metadata. Request status was still
+      ${JSON.stringify(resultsCreate.status)} after ${MAXIMUM_ATTEMPTS_DURATION_MS / 1000} seconds
+      and ${attemptCount} attempts.`,
       showResyncButton: true
     }
     return

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -132,9 +132,11 @@ def validate_metadata_task(self, rfc_to_be_id):
         repo = GithubRepository(repo_url)
         head_sha = repo.ref  # gets current head + guarantees all files from same ref
 
-        # if sha unchanged, skip processing
+        # if sha unchanged and status `success`, skip processing
         existing = MetadataValidationResults.objects.filter(
-            rfc_to_be=rfc_to_be, head_sha=head_sha
+            rfc_to_be=rfc_to_be,
+            head_sha=head_sha,
+            status=MetadataValidationResults.Status.SUCCESS,
         ).first()
         if existing:
             logger.info(


### PR DESCRIPTION
<img width="1125" height="400" alt="image" src="https://github.com/user-attachments/assets/98ad748d-149f-4e9f-a7e3-beeac9ddde8e" />

fixing the issue when the metadata result has a head_sha but the status is failed (when previous logic assumed that when the head_sha exists, its always a success)