### PR TITLE
feat: change default email

### DIFF
--- a/purple/settings/base.py
+++ b/purple/settings/base.py
@@ -154,7 +154,7 @@ CACHES = {
 
 # email
 EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
-DEFAULT_FROM_EMAIL = os.getenv("PURPLE_DEFAULT_FROM_EMAIL", "purple@rfc-editor.org")
+DEFAULT_FROM_EMAIL = os.getenv("PURPLE_DEFAULT_FROM_EMAIL", "rfc-editor@rfc-editor.org")
 MESSAGE_ID_DOMAIN = "rfc-editor.org"
 
 ADMINS = [("Some Admin", "admin@example.org")]


### PR DESCRIPTION
use rfc-editor@rfc-editor.org as default for emails sent from purple