### PR TITLE
feat: check action holders to determine in-final-review

### DIFF
--- a/client/app/components/FinalReviews.vue
+++ b/client/app/components/FinalReviews.vue
@@ -28,7 +28,7 @@ const {
   error,
 } = await useAsyncData(
   'final-review-pending-false',
-  () => api.queueList({ pendingFinalApproval: false }),
+  () => api.queueList({ pendingFinalReview: false }),
   {
     server: false,
     lazy: true,

--- a/client/app/components/FinalReviewsInProgress.vue
+++ b/client/app/components/FinalReviewsInProgress.vue
@@ -80,7 +80,7 @@ const {
   error,
 } = await useAsyncData(
   'final-review-in-progress',
-  () => api.queueList({ pendingFinalApproval: true }),
+  () => api.queueList({ pendingFinalReview: true }),
   {
     server: false,
     lazy: true,

--- a/client/app/pages/queue/pending-announcement.vue
+++ b/client/app/pages/queue/pending-announcement.vue
@@ -85,7 +85,7 @@ const {
   error,
 } = await useAsyncData(
   'queue2-pending-announcement',
-  () => api.queueList({ pendingFinalApproval: false }),
+  () => api.queueList({ pendingFinalReview: false }),
   {
     server: false,
     lazy: true,

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -69,9 +69,9 @@ paths:
         schema:
           type: boolean
         description: Filter by pending final review status. True returns drafts with
-          at least one pending author approval (FinalApproval) or uncompleted action
-          holder. False returns drafts where all author approvals are done and all
-          action holders are completed.
+          at least one pending author approval (FinalApproval) or at least one uncompleted
+          action holder. False returns drafts where at least one author approval exists,
+          all author approvals are done, and no action holders are uncompleted.
       tags:
       - purple
       security:
@@ -2634,9 +2634,9 @@ paths:
         schema:
           type: boolean
         description: Filter by pending final review status. True returns drafts with
-          at least one pending author approval (FinalApproval) or uncompleted action
-          holder. False returns drafts where all author approvals are done and all
-          action holders are completed.
+          at least one pending author approval (FinalApproval) or at least one uncompleted
+          action holder. False returns drafts where at least one author approval exists,
+          all author approvals are done, and no action holders are uncompleted.
       tags:
       - purple
       security:

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -64,6 +64,14 @@ paths:
         description: Filter by pending final approval status, true returns drafts
           with at least one pending final approval, false returns drafts where all
           final approvals are approved.
+      - in: query
+        name: pending_final_review
+        schema:
+          type: boolean
+        description: Filter by pending final review status. True returns drafts with
+          at least one pending author approval (FinalApproval) or uncompleted action
+          holder. False returns drafts where all author approvals are done and all
+          action holders are completed.
       tags:
       - purple
       security:
@@ -2621,6 +2629,14 @@ paths:
         description: Filter by pending final approval status, true returns drafts
           with at least one pending final approval, false returns drafts where all
           final approvals are approved.
+      - in: query
+        name: pending_final_review
+        schema:
+          type: boolean
+        description: Filter by pending final review status. True returns drafts with
+          at least one pending author approval (FinalApproval) or uncompleted action
+          holder. False returns drafts where all author approvals are done and all
+          action holders are completed.
       tags:
       - purple
       security:

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -681,9 +681,10 @@ class QueueFilter(django_filters.FilterSet):
     pending_final_review = django_filters.BooleanFilter(
         method="filter_pending_final_review",
         help_text="Filter by pending final review status. True returns drafts with "
-        "at least one pending author approval (FinalApproval) or uncompleted action "
-        "holder. False returns drafts where all author approvals are done and all "
-        "action holders are completed.",
+        "at least one pending author approval (FinalApproval) or at least one "
+        "uncompleted action holder. False returns drafts where at least one author "
+        "approval exists, all author approvals are done, and no action holders are "
+        "uncompleted.",
     )
 
     def filter_pending_final_approval(self, queryset, name, value):

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -674,7 +674,13 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
 class QueueFilter(django_filters.FilterSet):
     pending_final_approval = django_filters.BooleanFilter(
         method="filter_pending_final_approval",
-        help_text="Filter by pending final approval status. True returns drafts with "
+        help_text="Filter by pending final approval status, true returns drafts with "
+        "at least one pending final approval, false returns drafts where all final "
+        "approvals are approved.",
+    )
+    pending_final_review = django_filters.BooleanFilter(
+        method="filter_pending_final_review",
+        help_text="Filter by pending final review status. True returns drafts with "
         "at least one pending author approval (FinalApproval) or uncompleted action "
         "holder. False returns drafts where all author approvals are done and all "
         "action holders are completed.",
@@ -682,10 +688,28 @@ class QueueFilter(django_filters.FilterSet):
 
     def filter_pending_final_approval(self, queryset, name, value):
         if value is True:
+            # has at least one FinalApproval with approved=None
+            return queryset.filter(
+                finalapproval__isnull=False, finalapproval__approved__isnull=True
+            ).distinct()
+        elif value is False:
+            # ALL FinalApprovals are approved (no pending approvals)
+            return (
+                queryset.filter(finalapproval__isnull=False)
+                .exclude(finalapproval__approved__isnull=True)
+                .distinct()
+            )
+        return queryset
+
+    def filter_pending_final_review(self, queryset, name, value):
+        if value is True:
             # has at least one pending FinalApproval OR an uncompleted ActionHolder
             return queryset.filter(
                 Q(finalapproval__isnull=False, finalapproval__approved__isnull=True)
-                | Q(actionholder_set__completed__isnull=True)
+                | Q(
+                    actionholder_set__isnull=False,
+                    actionholder_set__completed__isnull=True,
+                )
             ).distinct()
         elif value is False:
             # ALL FinalApprovals are approved and no uncompleted ActionHolders
@@ -699,7 +723,7 @@ class QueueFilter(django_filters.FilterSet):
 
     class Meta:
         model = RfcToBe
-        fields = ["disposition", "pending_final_approval"]
+        fields = ["disposition", "pending_final_approval", "pending_final_review"]
 
 
 @extend_schema(operation_id="queue_counts", responses={200: QueueCountsSerializer})

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -674,22 +674,25 @@ def import_submission(request, document_id, rpcapi: rpcapi_client.PurpleApi):
 class QueueFilter(django_filters.FilterSet):
     pending_final_approval = django_filters.BooleanFilter(
         method="filter_pending_final_approval",
-        help_text="Filter by pending final approval status, true returns drafts with "
-        "at least one pending final approval, false returns drafts where all final "
-        "approvals are approved.",
+        help_text="Filter by pending final approval status. True returns drafts with "
+        "at least one pending author approval (FinalApproval) or uncompleted action "
+        "holder. False returns drafts where all author approvals are done and all "
+        "action holders are completed.",
     )
 
     def filter_pending_final_approval(self, queryset, name, value):
         if value is True:
-            # has at least one FinalApproval with approved=None
+            # has at least one pending FinalApproval OR an uncompleted ActionHolder
             return queryset.filter(
-                finalapproval__isnull=False, finalapproval__approved__isnull=True
+                Q(finalapproval__isnull=False, finalapproval__approved__isnull=True)
+                | Q(actionholder_set__completed__isnull=True)
             ).distinct()
         elif value is False:
-            # ALL FinalApprovals are approved (no pending approvals)
+            # ALL FinalApprovals are approved and no uncompleted ActionHolders
             return (
                 queryset.filter(finalapproval__isnull=False)
                 .exclude(finalapproval__approved__isnull=True)
+                .exclude(actionholder_set__completed__isnull=True)
                 .distinct()
             )
         return queryset


### PR DESCRIPTION
fix https://github.com/ietf-tools/queue/issues/54#issuecomment-4480168446 and same behavior in purple "Final Review" page

keep existing behavior and add new filter `pending_final_review` that takes both ActionHolders and FinalApprovals into account.

I didn't update the behavior of the existing `pending_final_approval` filter because that would have been semantically incorrect
