### PR TITLE
feat: mark enqueuer assignment as done once in queue

### DIFF
--- a/client/app/pages/docs/[id]/enqueue.vue
+++ b/client/app/pages/docs/[id]/enqueue.vue
@@ -68,7 +68,6 @@ import { QUEUE_QUEUE_PATH } from '~/utils/url'
 
 const route = useRoute()
 const api = useApi()
-const userStore = useUserStore()
 
 const draftName = computed(() => route.params.id?.toString() ?? '')
 
@@ -130,34 +129,10 @@ const isAddingToQueue = ref(false)
 
 const snackbar = useSnackbar()
 
-const IN_PROGRESS = 'in_progress'
-const ENQUEUER_ROLE = 'enqueuer'
-
 const addToQueue = async () => {
   isAddingToQueue.value = true
   try {
-    const rfcToBe = await api.documentsPartialUpdate({
-      draftName: draftName.value,
-      patchedRfcToBeRequest: {
-        disposition: IN_PROGRESS
-      }
-    })
-    if(rfcToBe.disposition !== IN_PROGRESS) {
-      throw Error(`Unable to set RFC to ${IN_PROGRESS}`)
-    }
-
-    // Create assignment for current user as enqueuer
-     if (rfcToBe.id) {
-       await api.assignmentsCreate({
-         assignmentRequest: {
-           rfcToBe: rfcToBe.id,
-           person: userStore.rpcPersonId,
-           role: ENQUEUER_ROLE,
-           state: IN_PROGRESS
-         }
-       })
-     }
-
+    await api.documentsEnqueue({ draftName: draftName.value })
     await navigateTo(QUEUE_QUEUE_PATH)
   } catch(e) {
     snackbarForErrors({ snackbar, error: e, defaultTitle: 'Unable to add to queue'})

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -718,6 +718,30 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/rpc/documents/{draft__name}/enqueue/:
+    post:
+      operationId: documents_enqueue
+      description: |-
+        Move a draft from 'created' to 'in_progress' and mark its enqueuer
+        assignment as DONE.
+      parameters:
+      - in: path
+        name: draft__name
+        schema:
+          type: string
+          description: Name of draft
+        required: true
+      tags:
+      - purple
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RfcToBe'
+          description: ''
   /api/rpc/documents/{draft__name}/history/:
     get:
       operationId: documents_history_list

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -1331,11 +1331,11 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
         enqueuer_role = RpcRole.objects.get(slug="enqueuer")
         rpc_person = request.user.rpcperson()
         if rpc_person is not None:
-            Assignment.objects.create(
+            Assignment.objects.update_or_create(
                 rfc_to_be=rfctobe,
                 role=enqueuer_role,
                 person=rpc_person,
-                state=Assignment.State.DONE,
+                defaults={"state": Assignment.State.DONE},
             )
         return Response(RfcToBeSerializer(rfctobe, context={"request": request}).data)
 

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -1312,6 +1312,34 @@ class RfcToBeViewSet(viewsets.ModelViewSet):
         return Response()
 
     @extend_schema(
+        operation_id="documents_enqueue",
+        request=None,
+        responses={200: RfcToBeSerializer},
+    )
+    @action(detail=True, methods=["post"], url_path="enqueue")
+    def enqueue(self, request, draft__name=None):
+        """Move a draft from 'created' to 'in_progress' and mark its enqueuer
+        assignment as DONE."""
+        rfctobe = self.get_object()
+        if rfctobe.disposition_id != "created":
+            raise serializers.ValidationError(
+                f"Cannot enqueue: disposition is '{rfctobe.disposition_id}', "
+                "expected 'created'."
+            )
+        rfctobe.disposition_id = DispositionName.IN_PROGRESS
+        rfctobe.save()
+        enqueuer_role = RpcRole.objects.get(slug="enqueuer")
+        rpc_person = request.user.rpcperson()
+        if rpc_person is not None:
+            Assignment.objects.create(
+                rfc_to_be=rfctobe,
+                role=enqueuer_role,
+                person=rpc_person,
+                state=Assignment.State.DONE,
+            )
+        return Response(RfcToBeSerializer(rfctobe, context={"request": request}).data)
+
+    @extend_schema(
         operation_id="documents_pub_status_retrieve",
         request=None,
         responses=PublishRfcStatusSerializer,


### PR DESCRIPTION
move logic from FE to BE.

create endpoint to move draft disposition from `created` to `in_progress` and add the person doing it as `enqueuer` with state `done`
(same behavior as done in xfer: once in queue, we consider enqueuer job done)



