### PR TITLE
feat: filter by assignment in final review

### DIFF
--- a/client/app/components/DocumentActionHolders.vue
+++ b/client/app/components/DocumentActionHolders.vue
@@ -132,7 +132,7 @@ const columns = [
   }),
   columnHelper.display({
     id: 'status',
-    header: 'Approval Status',
+    header: 'Date Completed',
     cell: data => {
       const completed = data.row.original.completed
       if (completed) {

--- a/purple_api.yaml
+++ b/purple_api.yaml
@@ -68,10 +68,12 @@ paths:
         name: pending_final_review
         schema:
           type: boolean
-        description: Filter by pending final review status. True returns drafts with
-          at least one pending author approval (FinalApproval) or at least one uncompleted
-          action holder. False returns drafts where at least one author approval exists,
-          all author approvals are done, and no action holders are uncompleted.
+        description: 'Filter by pending final review status. First filter by existing
+          final_review_editor assignment. Additional filters: True returns drafts
+          with at least one pending author approval (FinalApproval) or at least one
+          uncompleted action holder. False returns drafts where at least one author
+          approval exists, all author approvals are done, and no action holders are
+          uncompleted.'
       tags:
       - purple
       security:
@@ -2633,10 +2635,12 @@ paths:
         name: pending_final_review
         schema:
           type: boolean
-        description: Filter by pending final review status. True returns drafts with
-          at least one pending author approval (FinalApproval) or at least one uncompleted
-          action holder. False returns drafts where at least one author approval exists,
-          all author approvals are done, and no action holders are uncompleted.
+        description: 'Filter by pending final review status. First filter by existing
+          final_review_editor assignment. Additional filters: True returns drafts
+          with at least one pending author approval (FinalApproval) or at least one
+          uncompleted action holder. False returns drafts where at least one author
+          approval exists, all author approvals are done, and no action holders are
+          uncompleted.'
       tags:
       - purple
       security:

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -703,9 +703,10 @@ class QueueFilter(django_filters.FilterSet):
         return queryset
 
     def filter_pending_final_review(self, queryset, name, value):
+        has_fre = queryset.filter(assignment__role__slug="final_review_editor")
         if value is True:
             # has at least one pending FinalApproval OR an uncompleted ActionHolder
-            return queryset.filter(
+            return has_fre.filter(
                 Q(finalapproval__isnull=False, finalapproval__approved__isnull=True)
                 | Q(
                     actionholder_set__isnull=False,
@@ -715,7 +716,7 @@ class QueueFilter(django_filters.FilterSet):
         elif value is False:
             # ALL FinalApprovals are approved and no uncompleted ActionHolders
             return (
-                queryset.filter(finalapproval__isnull=False)
+                has_fre.filter(finalapproval__isnull=False)
                 .exclude(finalapproval__approved__isnull=True)
                 .exclude(actionholder_set__completed__isnull=True)
                 .distinct()

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -11,7 +11,7 @@ import rpcapi_client
 from django import forms
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Max, Prefetch, Q
+from django.db.models import Exists, Max, OuterRef, Prefetch, Q
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
@@ -704,7 +704,15 @@ class QueueFilter(django_filters.FilterSet):
         return queryset
 
     def filter_pending_final_review(self, queryset, name, value):
-        has_fre = queryset.filter(assignment__role__slug="final_review_editor")
+        # documents with at least one non-withdrawn final_review_editor assignment
+        has_fre = queryset.filter(
+            Exists(
+                Assignment.objects.filter(
+                    rfc_to_be=OuterRef("pk"),
+                    role__slug="final_review_editor",
+                ).exclude(state=Assignment.State.WITHDRAWN)
+            )
+        )
         if value is True:
             # has a final_review_editor assignment, and at least one pending
             # FinalApproval OR an uncompleted ActionHolder

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -721,7 +721,10 @@ class QueueFilter(django_filters.FilterSet):
             return (
                 has_fre.filter(finalapproval__isnull=False)
                 .exclude(finalapproval__approved__isnull=True)
-                .exclude(actionholder_set__completed__isnull=True)
+                .exclude(
+                    actionholder_set__isnull=False,
+                    actionholder_set__completed__isnull=True,
+                )
                 .distinct()
             )
         return queryset

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -680,11 +680,12 @@ class QueueFilter(django_filters.FilterSet):
     )
     pending_final_review = django_filters.BooleanFilter(
         method="filter_pending_final_review",
-        help_text="Filter by pending final review status. True returns drafts with "
-        "at least one pending author approval (FinalApproval) or at least one "
-        "uncompleted action holder. False returns drafts where at least one author "
-        "approval exists, all author approvals are done, and no action holders are "
-        "uncompleted.",
+        help_text="Filter by pending final review status. First filter by existing "
+        "final_review_editor assignment. Additional filters: "
+        "True returns drafts with at least one pending author approval (FinalApproval) "
+        "or at least one uncompleted action holder. False returns drafts where at "
+        "least one author approval exists, all author approvals are done, and no "
+        "action holders are uncompleted.",
     )
 
     def filter_pending_final_approval(self, queryset, name, value):
@@ -705,7 +706,8 @@ class QueueFilter(django_filters.FilterSet):
     def filter_pending_final_review(self, queryset, name, value):
         has_fre = queryset.filter(assignment__role__slug="final_review_editor")
         if value is True:
-            # has at least one pending FinalApproval OR an uncompleted ActionHolder
+            # has a final_review_editor assignment, and at least one pending
+            # FinalApproval OR an uncompleted ActionHolder
             return has_fre.filter(
                 Q(finalapproval__isnull=False, finalapproval__approved__isnull=True)
                 | Q(
@@ -714,7 +716,8 @@ class QueueFilter(django_filters.FilterSet):
                 )
             ).distinct()
         elif value is False:
-            # ALL FinalApprovals are approved and no uncompleted ActionHolders
+            # has a final_review_editor assignment, ALL FinalApprovals are approved,
+            # and no uncompleted ActionHolders
             return (
                 has_fre.filter(finalapproval__isnull=False)
                 .exclude(finalapproval__approved__isnull=True)


### PR DESCRIPTION
fixes https://github.com/ietf-tools/purple/issues/702

current logic requires Action Holder to be **present**, and completed.
Expected logic: either no ActionHolder or all completed

Additional filter: we ALWAYS expect that draft has at least a final review editor assignment