### PR TITLE
chore: point nginx to 127.0.0.1, not localhost

### DIFF
--- a/k8s/nginx-purple.conf
+++ b/k8s/nginx-purple.conf
@@ -1,3 +1,15 @@
+upstream purple_frontend {
+    server 127.0.0.1:3000;
+}
+
+upstream purple_backend {
+    server 127.0.0.1:8000;
+}
+
+upstream purple_statics {
+    server 127.0.0.1:8042;
+}
+
 server {
     listen 8080 default_server;
     listen [::]:8080 default_server;
@@ -22,7 +34,7 @@ server {
         proxy_set_header Connection close;
         proxy_set_header X-Request-Start "t=$${keepempty}msec";
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
-        proxy_pass http://localhost:8000;
+        proxy_pass http://purple_backend;
         # Set timeouts longer than Cloudflare proxy limits
         proxy_connect_timeout 60;  # nginx default (Cf = 15)
         proxy_read_timeout 120;  # nginx default = 60 (Cf = 100)
@@ -39,7 +51,7 @@ server {
         proxy_set_header Connection close;
         proxy_set_header X-Request-Start "t=$${keepempty}msec";
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
-        proxy_pass http://localhost:8042;
+        proxy_pass http://purple_statics;
         # Set timeouts longer than Cloudflare proxy limits
         proxy_connect_timeout 60;  # nginx default (Cf = 15)
         proxy_read_timeout 120;  # nginx default = 60 (Cf = 100)
@@ -52,7 +64,7 @@ server {
         proxy_set_header Connection close;
         proxy_set_header X-Request-Start "t=$${keepempty}msec";
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
-        proxy_pass http://localhost:3000;
+        proxy_pass http://purple_frontend;
         # Set timeouts longer than Cloudflare proxy limits
         proxy_connect_timeout 60;  # nginx default (Cf = 15)
         proxy_read_timeout 120;  # nginx default = 60 (Cf = 100)


### PR DESCRIPTION
Avoids proxy-related errors in logs.