### PR TITLE
feat: improve the labels management

### DIFF
--- a/client/app/components/LabelsSection.vue
+++ b/client/app/components/LabelsSection.vue
@@ -9,12 +9,19 @@
         class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-neutral-700 dark:bg-neutral-800"
       >
         <RpcLabel :label="label" />
-        <Icon
-          v-if="editable"
-          name="circum:edit"
-          class="ml-3 shrink-0 text-indigo-600 hover:text-indigo-900 cursor-pointer"
-          @click="$emit('edit', label)"
-        />
+        <div class="flex items-center gap-2 ml-3 shrink-0">
+          <Icon
+            name="circum:edit"
+            class="text-indigo-600 hover:text-indigo-900 cursor-pointer"
+            @click="$emit('edit', label)"
+          />
+          <Icon
+            v-if="deletable"
+            name="circum:trash"
+            class="text-red-500 hover:text-red-700 cursor-pointer"
+            @click="$emit('delete', label)"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -26,10 +33,11 @@ import type { Label } from '~/purple_client'
 defineProps<{
   title: string
   labels: Label[]
-  editable?: boolean
+  deletable?: boolean
 }>()
 
 defineEmits<{
   edit: [label: Label]
+  delete: [label: Label]
 }>()
 </script>

--- a/client/app/components/LabelsSection.vue
+++ b/client/app/components/LabelsSection.vue
@@ -9,19 +9,11 @@
         class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-neutral-700 dark:bg-neutral-800"
       >
         <RpcLabel :label="label" />
-        <div class="flex items-center gap-2 ml-3 shrink-0">
-          <Icon
-            name="circum:edit"
-            class="text-indigo-600 hover:text-indigo-900 cursor-pointer"
-            @click="$emit('edit', label)"
-          />
-          <Icon
-            v-if="deletable"
-            name="circum:trash"
-            class="text-red-500 hover:text-red-700 cursor-pointer"
-            @click="$emit('delete', label)"
-          />
-        </div>
+        <Icon
+          name="circum:edit"
+          class="ml-3 shrink-0 text-indigo-600 hover:text-indigo-900 cursor-pointer"
+          @click="$emit('edit', label)"
+        />
       </div>
     </div>
   </div>
@@ -33,11 +25,9 @@ import type { Label } from '~/purple_client'
 defineProps<{
   title: string
   labels: Label[]
-  deletable?: boolean
 }>()
 
 defineEmits<{
   edit: [label: Label]
-  delete: [label: Label]
 }>()
 </script>

--- a/client/app/components/LabelsSection.vue
+++ b/client/app/components/LabelsSection.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="mt-8">
+    <h2 class="text-sm font-semibold text-gray-700 dark:text-neutral-400 mb-3">{{ title }}</h2>
+    <p v-if="labels.length === 0" class="text-sm text-gray-500 italic">(None)</p>
+    <div v-else class="grid grid-cols-4 gap-3">
+      <div
+        v-for="label in labels"
+        :key="label.slug"
+        class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-neutral-700 dark:bg-neutral-800"
+      >
+        <RpcLabel :label="label" />
+        <Icon
+          v-if="editable"
+          name="circum:edit"
+          class="ml-3 shrink-0 text-indigo-600 hover:text-indigo-900 cursor-pointer"
+          @click="$emit('edit', label)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Label } from '~/purple_client'
+
+defineProps<{
+  title: string
+  labels: Label[]
+  editable?: boolean
+}>()
+
+defineEmits<{
+  edit: [label: Label]
+}>()
+</script>

--- a/client/app/components/RpcLabelEditDialog.vue
+++ b/client/app/components/RpcLabelEditDialog.vue
@@ -98,13 +98,13 @@
 
         <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
           <label for="is-used" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">
-            May be Used
+            Is Assignable
           </label>
           <div class="mt-2 sm:col-span-2 sm:mt-0">
             <input
               id="is-used" v-model="label.used" name="is-used" type="checkbox"
               class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
-            <p class="text-gray-500">Uncheck for labels that shall not be assignable.</p>
+            <p class="text-gray-500">This label is assignable and actively in use.</p>
           </div>
         </div>
       </div>

--- a/client/app/components/RpcLabelEditDialog.vue
+++ b/client/app/components/RpcLabelEditDialog.vue
@@ -37,7 +37,7 @@
               <input
                 id="slug" v-model="label.slug" type="text" name="slug"
                 class="block flex-1 border-0 bg-transparent py-1.5 pl-1 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
-                placeholder="happy tree">
+                placeholder="e.g. `markdown`">
             </div>
           </div>
         </div>
@@ -67,13 +67,32 @@
         </div>
 
         <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-          <label for="color" class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">Color</label>
+          <label class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5">Color</label>
           <div class="mt-2 sm:col-span-2 sm:mt-0">
-            <select
-              id="color" v-model="label.color" name="color"
-              class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6">
-              <option v-for="color of ColorEnum" :key="color">{{ color }}</option>
-            </select>
+            <HeadlessListbox v-model="label.color" as="div" class="relative sm:max-w-xs">
+              <HeadlessListboxButton
+                class="relative w-full cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"
+              >
+                <span :class="['inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset', badgeColors[label.color as ColorEnum]]">
+                  {{ label.color }}
+                </span>
+                <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                  <Icon name="heroicons:chevron-up-down-solid" class="h-5 w-5 text-gray-400" aria-hidden="true" />
+                </span>
+              </HeadlessListboxButton>
+              <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
+                <HeadlessListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                  <HeadlessListboxOption v-for="color in ColorEnum" :key="color" :value="color" v-slot="{ active, selected }">
+                    <div :class="['flex cursor-default select-none items-center px-3 py-2 gap-2', active ? 'bg-gray-100' : '']">
+                      <span :class="['inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset', badgeColors[color]]">
+                        {{ color }}
+                      </span>
+                      <Icon v-if="selected" name="heroicons:check-solid" class="h-4 w-4 text-indigo-600" />
+                    </div>
+                  </HeadlessListboxOption>
+                </HeadlessListboxOptions>
+              </transition>
+            </HeadlessListbox>
           </div>
         </div>
 
@@ -85,7 +104,7 @@
             <input
               id="is-used" v-model="label.used" name="is-used" type="checkbox"
               class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
-            <p class="text-gray-500">This label is still in use.</p>
+            <p class="text-gray-500">Uncheck for labels that shall not be assignable.</p>
           </div>
         </div>
       </div>
@@ -97,6 +116,7 @@
 <script setup lang="ts">
 import { ColorEnum } from '~/purple_client'
 import type { Label } from '~/purple_client'
+import { badgeColors } from '~/utils/badge'
 import { overlayModalMethodsKey } from '../providers/providerKeys'
 
 const api = useApi()

--- a/client/app/components/RpcLabelEditDialog.vue
+++ b/client/app/components/RpcLabelEditDialog.vue
@@ -37,7 +37,7 @@
               <input
                 id="slug" v-model="label.slug" type="text" name="slug"
                 class="block flex-1 border-0 bg-transparent py-1.5 pl-1 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
-                placeholder="e.g. `markdown`">
+                placeholder="e.g. 'markdown'">
             </div>
           </div>
         </div>

--- a/client/app/pages/labels/index.vue
+++ b/client/app/pages/labels/index.vue
@@ -16,8 +16,8 @@
       API error while requesting labels: {{ labelsError }}
     </ErrorAlert>
     <template v-else>
-      <LabelsSection title="In Use" :labels="labelsInUse" :editable="true" @edit="editLabel" />
-      <LabelsSection title="Not in Use" :labels="labelsNotInUse" />
+      <LabelsSection title="In Use" :labels="labelsInUse" @edit="editLabel" />
+      <LabelsSection title="Not in Use" :labels="labelsNotInUse" :deletable="true" @edit="editLabel" @delete="deleteLabel" />
     </template>
   </div>
 </template>
@@ -65,6 +65,22 @@ async function addLabel() {
   if (refresh) {
     await refresh()
   }
+}
+
+async function deleteLabel(label: Label) {
+  if (!label.id) return
+  try {
+    await api.labelsDestroy({ id: label.id })
+  } catch {
+    snackbar.add({
+      type: 'error',
+      title: 'Delete failed',
+      text: 'Label could not be deleted — it may still be assigned to documents'
+    })
+    return
+  }
+  snackbar.add({ type: 'success', title: 'Success', text: 'Label deleted' })
+  if (refresh) await refresh()
 }
 
 async function editLabel(label: Label) {

--- a/client/app/pages/labels/index.vue
+++ b/client/app/pages/labels/index.vue
@@ -16,8 +16,8 @@
       API error while requesting labels: {{ labelsError }}
     </ErrorAlert>
     <template v-else>
-      <LabelsSection title="In Use" :labels="labelsInUse" @edit="editLabel" />
-      <LabelsSection title="Not in Use" :labels="labelsNotInUse" :deletable="true" @edit="editLabel" @delete="deleteLabel" />
+      <LabelsSection title="Assignable" :labels="labelsInUse" @edit="editLabel" />
+      <LabelsSection title="Not Assignable" :labels="labelsNotInUse" @edit="editLabel" />
     </template>
   </div>
 </template>
@@ -67,21 +67,6 @@ async function addLabel() {
   }
 }
 
-async function deleteLabel(label: Label) {
-  if (!label.id) return
-  try {
-    await api.labelsDestroy({ id: label.id })
-  } catch {
-    snackbar.add({
-      type: 'error',
-      title: 'Delete failed',
-      text: 'Label could not be deleted — it may still be assigned to documents'
-    })
-    return
-  }
-  snackbar.add({ type: 'success', title: 'Success', text: 'Label deleted' })
-  if (refresh) await refresh()
-}
 
 async function editLabel(label: Label) {
   try {

--- a/client/app/pages/labels/index.vue
+++ b/client/app/pages/labels/index.vue
@@ -15,38 +15,10 @@
     <ErrorAlert v-if="labelsError" title="API Error">
       API error while requesting labels: {{ labelsError }}
     </ErrorAlert>
-    <div v-else class="mt-8 flow-root">
-      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-        <div class="inline-block min-w-fit py-2 align-middle sm:px-6 lg:px-8">
-          <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
-            <table class="min-w-fit divide-y divide-gray-300">
-              <thead class="bg-gray-50">
-              <tr>
-                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-                <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                  <span class="sr-only">Edit</span>
-                </th>
-              </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-200 bg-white">
-              <tr v-for="label in sortedLabels" :key="label.slug">
-                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                  <RpcLabel :label="label"/>
-                  <Icon v-if="!label.used" name="heroicons:x-mark-solid" class="text-red-500"/>
-                </td>
-                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                  <Icon
-                    name="circum:edit" class="text-indigo-600 hover:text-indigo-900 cursor-pointer"
-                    @click="editLabel(label)"/>
-                  <span class="sr-only">Edit {{ label.slug }}</span>
-                </td>
-              </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
+    <template v-else>
+      <LabelsSection title="In Use" :labels="labelsInUse" :editable="true" @edit="editLabel" />
+      <LabelsSection title="Not in Use" :labels="labelsNotInUse" />
+    </template>
   </div>
 </template>
 
@@ -59,6 +31,8 @@ const api = useApi()
 const snackbar = useSnackbar()
 
 const sortedLabels = computed(() => labels.value?.toSorted((a, b) => a.slug.localeCompare(b.slug, 'en')) ?? [])
+const labelsInUse = computed(() => sortedLabels.value.filter(l => l.used))
+const labelsNotInUse = computed(() => sortedLabels.value.filter(l => !l.used))
 
 const { data: labels, error: labelsError, refresh } = await useAsyncData(
   () => api.labelsList(),


### PR DESCRIPTION
<img width="1411" height="618" alt="image" src="https://github.com/user-attachments/assets/f3d0a32e-d9a3-46ef-9a5d-235c019857b9" />

separate in use and not in use

(added edit options for the `not in used`, to be able to switch to "in use")
as requested by @sginoza


