### PR TITLE
fix: add person for final approver that doesn't exist yet

### DIFF
--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -2068,13 +2068,13 @@ class CreateFinalApprovalSerializer(FinalApprovalSerializer):
             "overriding_approver_person_id", None
         )
 
-        approver_dt_person = DatatrackerPerson.objects.get(
+        approver_dt_person, _ = DatatrackerPerson.objects.get_or_create(
             datatracker_id=approver_person_id
         )
 
         overriding_approver_dt_person = None
         if overriding_approver_person_id:
-            overriding_approver_dt_person = DatatrackerPerson.objects.get(
+            overriding_approver_dt_person, _ = DatatrackerPerson.objects.get_or_create(
                 datatracker_id=overriding_approver_person_id
             )
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -2068,13 +2068,13 @@ class CreateFinalApprovalSerializer(FinalApprovalSerializer):
             "overriding_approver_person_id", None
         )
 
-        approver_dt_person, _ = DatatrackerPerson.objects.get_or_create(
+        approver_dt_person, _ = DatatrackerPerson.objects.first_or_create(
             datatracker_id=approver_person_id
         )
 
         overriding_approver_dt_person = None
         if overriding_approver_person_id:
-            overriding_approver_dt_person, _ = DatatrackerPerson.objects.get_or_create(
+            overriding_approver_dt_person, _ = DatatrackerPerson.objects.first_or_create(
                 datatracker_id=overriding_approver_person_id
             )
 

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -2074,8 +2074,10 @@ class CreateFinalApprovalSerializer(FinalApprovalSerializer):
 
         overriding_approver_dt_person = None
         if overriding_approver_person_id:
-            overriding_approver_dt_person, _ = DatatrackerPerson.objects.first_or_create(
-                datatracker_id=overriding_approver_person_id
+            overriding_approver_dt_person, _ = (
+                DatatrackerPerson.objects.first_or_create(
+                    datatracker_id=overriding_approver_person_id
+                )
             )
 
         return FinalApproval.objects.create(


### PR DESCRIPTION
provides the short term fix https://github.com/ietf-tools/purple/issues/1283 and avoids the error reported.

Since `datatracker_person_id` is (currently) NOT unique, we should use `first_or_create` in case a merge has happended and multiple entries share same ID

