### PR TITLE
fix: trigger history for approvallogs

### DIFF
--- a/rpc/lifecycle/notifications.py
+++ b/rpc/lifecycle/notifications.py
@@ -178,6 +178,8 @@ def process_rfctobe_changes_for_queue():
         task_run.last_run_at = current_check_time
         logger.info("Completed processing history changes")
 
+        return f"Drafts updated since last check: {queue_rfcs.count()}"
+
     except Exception as e:
         logger.exception(f"Unexpected error in process_rfctobe_changes_for_queue: {e}")
         raise

--- a/rpc/lifecycle/notifications.py
+++ b/rpc/lifecycle/notifications.py
@@ -178,7 +178,7 @@ def process_rfctobe_changes_for_queue():
         task_run.last_run_at = current_check_time
         logger.info("Completed processing history changes")
 
-        return f"Drafts updated since last check: {queue_rfcs.count()}"
+        return queue_rfcs.count()
 
     except Exception as e:
         logger.exception(f"Unexpected error in process_rfctobe_changes_for_queue: {e}")

--- a/rpc/serializers.py
+++ b/rpc/serializers.py
@@ -618,10 +618,10 @@ class ApprovalLogMessageSerializer(serializers.Serializer):
         return ApprovalLogMessage.objects.create(**validated_data)
 
     def update(self, instance, validated_data):
-        ApprovalLogMessage.objects.filter(pk=instance.pk).update(
-            **validated_data,
-        )
-        return ApprovalLogMessage.objects.get(pk=instance.pk)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        return instance
 
 
 class PublicQueueAuthorSerializer(RfcAuthorSerializer):

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -211,7 +211,9 @@ def publish_rfctobe_task(self, rfctobe_id, expected_head):
 def process_rfctobe_changes_for_queue_task():
     """Check for changes to in-progress RFCs and send notifications"""
     try:
-        return process_rfctobe_changes_for_queue()
+        change_count = process_rfctobe_changes_for_queue()
+        logger.info(f"Detected {change_count} RFC changes for queue")
+        return f"Queue changes pushed ({change_count} RFCs changed)"
     except Exception as e:
         logger.error(f"Error in process_rfctobe_changes_for_queue_task: {e}")
 

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -211,7 +211,7 @@ def publish_rfctobe_task(self, rfctobe_id, expected_head):
 def process_rfctobe_changes_for_queue_task():
     """Check for changes to in-progress RFCs and send notifications"""
     try:
-        process_rfctobe_changes_for_queue()
+        return process_rfctobe_changes_for_queue()
     except Exception as e:
         logger.error(f"Error in process_rfctobe_changes_for_queue_task: {e}")
 


### PR DESCRIPTION
this fixes the current bug that updates are not pushed to queue site after existing approvallog message has been updated, since this didn't trigger a history entry.

also return message to display in log files