### PR TITLE
fix: API client generator error for queue count

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -743,7 +743,11 @@ class QueueFilter(django_filters.FilterSet):
         fields = ["disposition", "pending_final_approval", "pending_final_review"]
 
 
-@extend_schema(operation_id="queue_counts", responses={200: QueueCountsSerializer})
+@extend_schema_view(
+    get=extend_schema(
+        operation_id="queue_counts", responses={200: QueueCountsSerializer}
+    )
+)
 class QueueCounts(views.APIView):
     """Item counts for each queue tab"""
 


### PR DESCRIPTION
fix
```
Error: using @extend_schema on viewset class QueueCounts with parameters operation_id or operation will most likely result in a broken schema.
Errors:   1 (1 unique)
If not set, add @ts-nocheck in runtime.ts to avoid type errors from generated code
```