### PR TITLE
feat: add task to backfill final_review start dates

### DIFF
--- a/rpc/lifecycle/final_review.py
+++ b/rpc/lifecycle/final_review.py
@@ -1,0 +1,134 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+import datetime
+import logging
+
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+# (draft_name, start_date) — start_date is when the final_review_editor assignment was
+# created
+FINAL_REVIEW_START_DATES = [
+    ("draft-ietf-tls-rfc8446bis", "2025-12-15"),
+    ("draft-ietf-tls-keylogfile", "2025-12-16"),
+    ("draft-ietf-tls-tls12-frozen", "2026-01-05"),
+    ("draft-ietf-uta-require-tls13", "2026-01-06"),
+    ("draft-ietf-stir-servprovider-oob", "2025-10-21"),
+    ("draft-ietf-pce-pceps-tls13", "2026-01-16"),
+    ("draft-ietf-netconf-over-tls13", "2026-01-16"),
+    ("draft-ietf-lamps-rfc5019bis", "2026-01-16"),
+    ("draft-ietf-pce-sid-algo", "2026-02-19"),
+    ("draft-ietf-cose-merkle-tree-proofs", "2026-03-06"),
+    ("draft-ietf-scitt-architecture", "2026-03-06"),
+    ("draft-ietf-tls-hybrid-design", "2026-04-03"),
+    ("draft-ietf-pquip-hybrid-signature-spectrums", "2026-04-03"),
+    ("draft-ietf-pquip-pqc-engineers", "2026-04-27"),
+    ("draft-ietf-emu-bootstrapped-tls", "2026-04-27"),
+    ("draft-ietf-stir-rfc4916-update", "2026-05-01"),
+    ("draft-ietf-bmwg-mlrsearch", "2026-05-13"),
+    ("draft-ietf-tls-8773bis", "2026-04-06"),
+    ("draft-ietf-bier-oam-requirements", "2026-05-04"),
+    ("draft-ietf-dnsop-cds-consistency", "2026-05-06"),
+    ("draft-ietf-opsawg-prefix-lengths", "2026-05-06"),
+    ("draft-ietf-bfd-stability", "2026-05-07"),
+    ("draft-ietf-mailmaint-messageflag-mailboxattribute", "2026-05-07"),
+    ("draft-ietf-openpgp-pqc", "2026-05-08"),
+    ("draft-ietf-sidrops-manifest-numbers", "2026-05-08"),
+    ("draft-ietf-calext-jscontact-uid", "2026-05-12"),
+    ("draft-ietf-netconf-udp-client-server", "2026-05-13"),
+    ("draft-ietf-bfd-optimizing-authentication", "2026-05-19"),
+    ("draft-ietf-sshm-ssh-agent", "2026-05-14"),
+    ("draft-ietf-avtcore-rtp-haptics", "2026-05-18"),
+]
+
+
+def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
+    """Backfill missing history creation entries for final_review_editor assignments.
+
+    Returns (added, skipped).
+    """
+    from rpc.models import Assignment, RfcToBe
+
+    HistoricalAssignment = Assignment.history.model
+    added = 0
+    skipped = 0
+
+    for draft_name, date_str in FINAL_REVIEW_START_DATES:
+        start_date = timezone.make_aware(
+            datetime.datetime.strptime(date_str, "%Y-%m-%d").replace(hour=12)
+        )
+
+        rfctobe = (
+            RfcToBe.objects.filter(draft__name=draft_name)
+            .select_related("draft")
+            .first()
+        )
+        if not rfctobe:
+            logger.warning(
+                "backfill_final_review_history: no RfcToBe found for %s", draft_name
+            )
+            skipped += 1
+            continue
+
+        assignments = Assignment.objects.filter(
+            rfc_to_be=rfctobe,
+            role__slug="final_review_editor",
+        ).select_related("role", "person")
+
+        if not assignments.exists():
+            logger.warning(
+                "backfill_final_review_history: no final_review_editor assignment "
+                "for %s",
+                rfctobe.name,
+            )
+            skipped += 1
+            continue
+
+        for assignment in assignments:
+            existing = HistoricalAssignment.objects.filter(
+                id=assignment.id, history_type="+"
+            ).first()
+
+            if existing:
+                if existing.history_date == start_date:
+                    logger.info(
+                        "backfill_final_review_history: %s assignment #%s already has "
+                        "correct date %s, skipping",
+                        rfctobe.name, assignment.id, date_str,
+                    )
+                    skipped += 1
+                    continue
+                if not dry_run:
+                    existing.history_date = start_date
+                    existing.save(update_fields=["history_date"])
+                prefix = "[DRY RUN] " if dry_run else ""
+                logger.info(
+                    "backfill_final_review_history: %supdated history_date for %s "
+                    "assignment #%s → %s",
+                    prefix, rfctobe.name, assignment.id, date_str,
+                )
+            else:
+                if not dry_run:
+                    HistoricalAssignment.objects.create(
+                        id=assignment.id,
+                        rfc_to_be=rfctobe,
+                        person=assignment.person,
+                        role=assignment.role,
+                        state=assignment.state,
+                        comment=assignment.comment,
+                        time_spent=assignment.time_spent,
+                        history_date=start_date,
+                        history_type="+",
+                        history_user=None,
+                        history_change_reason="Backfilled final review start date",
+                    )
+                prefix = "[DRY RUN] " if dry_run else ""
+                logger.info(
+                    "backfill_final_review_history: %screated history for %s "
+                    "assignment #%s → %s",
+                    prefix, rfctobe.name, assignment.id, date_str,
+                )
+            added += 1
+
+    return added, skipped

--- a/rpc/lifecycle/final_review.py
+++ b/rpc/lifecycle/final_review.py
@@ -87,7 +87,9 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
             continue
         if not dry_run:
             existing.history_date = start_date
-            existing.history_change_reason = "Backfilled final review start date"
+            existing.history_change_reason = (
+                "Added (Backfilled final review start date)"
+            )
             existing.save(update_fields=["history_date", "history_change_reason"])
         prefix = "[DRY RUN] " if dry_run else ""
         logger.info(

--- a/rpc/lifecycle/final_review.py
+++ b/rpc/lifecycle/final_review.py
@@ -5,39 +5,39 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# (draft_name, start_date) — start_date is when the final_review_editor assignment was
-# created
+# (draft_name, start_date, assignment_pk) — assignment_pk is the PK of the first
+# final_review_editor Assignment for that draft; start_date is when it was created
 FINAL_REVIEW_START_DATES = [
-    ("draft-ietf-tls-rfc8446bis", "2025-12-15"),
-    ("draft-ietf-tls-keylogfile", "2025-12-16"),
-    ("draft-ietf-tls-tls12-frozen", "2026-01-05"),
-    ("draft-ietf-uta-require-tls13", "2026-01-06"),
-    ("draft-ietf-stir-servprovider-oob", "2025-10-21"),
-    ("draft-ietf-pce-pceps-tls13", "2026-01-16"),
-    ("draft-ietf-netconf-over-tls13", "2026-01-16"),
-    ("draft-ietf-lamps-rfc5019bis", "2026-01-16"),
-    ("draft-ietf-pce-sid-algo", "2026-02-19"),
-    ("draft-ietf-cose-merkle-tree-proofs", "2026-03-06"),
-    ("draft-ietf-scitt-architecture", "2026-03-06"),
-    ("draft-ietf-tls-hybrid-design", "2026-04-03"),
-    ("draft-ietf-pquip-hybrid-signature-spectrums", "2026-04-03"),
-    ("draft-ietf-pquip-pqc-engineers", "2026-04-27"),
-    ("draft-ietf-emu-bootstrapped-tls", "2026-04-27"),
-    ("draft-ietf-stir-rfc4916-update", "2026-05-01"),
-    ("draft-ietf-bmwg-mlrsearch", "2026-05-13"),
-    ("draft-ietf-tls-8773bis", "2026-04-06"),
-    ("draft-ietf-bier-oam-requirements", "2026-05-04"),
-    ("draft-ietf-dnsop-cds-consistency", "2026-05-06"),
-    ("draft-ietf-opsawg-prefix-lengths", "2026-05-06"),
-    ("draft-ietf-bfd-stability", "2026-05-07"),
-    ("draft-ietf-mailmaint-messageflag-mailboxattribute", "2026-05-07"),
-    ("draft-ietf-openpgp-pqc", "2026-05-08"),
-    ("draft-ietf-sidrops-manifest-numbers", "2026-05-08"),
-    ("draft-ietf-calext-jscontact-uid", "2026-05-12"),
-    ("draft-ietf-netconf-udp-client-server", "2026-05-13"),
-    ("draft-ietf-bfd-optimizing-authentication", "2026-05-19"),
-    ("draft-ietf-sshm-ssh-agent", "2026-05-14"),
-    ("draft-ietf-avtcore-rtp-haptics", "2026-05-18"),
+    ("draft-ietf-tls-rfc8446bis", "2025-12-15", 154),
+    ("draft-ietf-tls-keylogfile", "2025-12-16", 114),
+    ("draft-ietf-tls-tls12-frozen", "2026-01-05", 120),
+    ("draft-ietf-uta-require-tls13", "2026-01-06", 126),
+    ("draft-ietf-stir-servprovider-oob", "2025-10-21", 144),
+    ("draft-ietf-pce-pceps-tls13", "2026-01-16", 30),
+    ("draft-ietf-netconf-over-tls13", "2026-01-16", 36),
+    ("draft-ietf-lamps-rfc5019bis", "2026-01-16", 88),
+    ("draft-ietf-pce-sid-algo", "2026-02-19", 193),
+    ("draft-ietf-cose-merkle-tree-proofs", "2026-03-06", 170),
+    ("draft-ietf-scitt-architecture", "2026-03-06", 182),
+    ("draft-ietf-tls-hybrid-design", "2026-04-03", 175),
+    ("draft-ietf-pquip-hybrid-signature-spectrums", "2026-04-03", 3),
+    ("draft-ietf-pquip-pqc-engineers", "2026-04-27", 137),
+    ("draft-ietf-emu-bootstrapped-tls", "2026-04-27", 188),
+    ("draft-ietf-stir-rfc4916-update", "2026-05-01", 213),
+    ("draft-ietf-bmwg-mlrsearch", "2026-05-13", 218),
+    ("draft-ietf-tls-8773bis", "2026-04-06", 162),
+    ("draft-ietf-bier-oam-requirements", "2026-05-04", 51),
+    ("draft-ietf-dnsop-cds-consistency", "2026-05-06", 256),
+    ("draft-ietf-opsawg-prefix-lengths", "2026-05-06", 262),
+    ("draft-ietf-bfd-stability", "2026-05-07", 234),
+    ("draft-ietf-mailmaint-messageflag-mailboxattribute", "2026-05-07", 268),
+    ("draft-ietf-openpgp-pqc", "2026-05-08", 200),
+    ("draft-ietf-sidrops-manifest-numbers", "2026-05-08", 311),
+    ("draft-ietf-calext-jscontact-uid", "2026-05-12", 305),
+    ("draft-ietf-netconf-udp-client-server", "2026-05-13", 275),
+    ("draft-ietf-bfd-optimizing-authentication", "2026-05-19", 241),
+    ("draft-ietf-sshm-ssh-agent", "2026-05-14", 373),
+    ("draft-ietf-avtcore-rtp-haptics", "2026-05-18", 317),
 ]
 
 
@@ -46,57 +46,29 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
 
     Returns (added, skipped).
     """
-    from rpc.models import Assignment, RfcToBe
+    from rpc.models import Assignment
 
     HistoricalAssignment = Assignment.history.model
     added = 0
     skipped = 0
 
-    for draft_name, date_str in FINAL_REVIEW_START_DATES:
+    for draft_name, date_str, assignment_pk in FINAL_REVIEW_START_DATES:
         start_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").replace(
             hour=12, tzinfo=datetime.UTC
         )
 
-        rfctobe = (
-            RfcToBe.objects.filter(draft__name=draft_name)
-            .select_related("draft")
-            .first()
-        )
-        if not rfctobe:
-            logger.warning(
-                "backfill_final_review_history: no RfcToBe found for %s", draft_name
-            )
-            skipped += 1
-            continue
-
-        assignment = (
-            Assignment.objects.filter(
-                rfc_to_be=rfctobe,
-                role__slug="final_review_editor",
-            )
-            .order_by("id")
-            .first()
-        )
-
-        if assignment is None:
-            logger.warning(
-                "backfill_final_review_history: no final_review_editor assignment "
-                "for %s",
-                rfctobe.name,
-            )
-            skipped += 1
-            continue
-
         existing_qs = HistoricalAssignment.objects.filter(
-            id=assignment.id, history_type="+"
+            id=assignment_pk,
+            history_type="+",
+            rfc_to_be__draft__name=draft_name,
         )
         count = existing_qs.count()
         if count != 1:
             logger.warning(
                 "backfill_final_review_history: expected 1 history entry for %s "
-                "assignment #%s, found %d, skipping",
-                rfctobe.name,
-                assignment.id,
+                "assignment #%d, found %d, skipping",
+                draft_name,
+                assignment_pk,
                 count,
             )
             skipped += 1
@@ -105,24 +77,25 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
 
         if existing.history_date == start_date:
             logger.info(
-                "backfill_final_review_history: %s assignment #%s already has "
+                "backfill_final_review_history: %s assignment #%d already has "
                 "correct date %s, skipping",
-                rfctobe.name,
-                assignment.id,
+                draft_name,
+                assignment_pk,
                 date_str,
             )
             skipped += 1
             continue
         if not dry_run:
             existing.history_date = start_date
-            existing.save(update_fields=["history_date"])
+            existing.history_change_reason = "Backfilled final review start date"
+            existing.save(update_fields=["history_date", "history_change_reason"])
         prefix = "[DRY RUN] " if dry_run else ""
         logger.info(
             "backfill_final_review_history: %supdated history_date for %s "
-            "assignment #%s → %s",
+            "assignment #%d → %s",
             prefix,
-            rfctobe.name,
-            assignment.id,
+            draft_name,
+            assignment_pk,
             date_str,
         )
         added += 1

--- a/rpc/lifecycle/final_review.py
+++ b/rpc/lifecycle/final_review.py
@@ -95,7 +95,9 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
                     logger.info(
                         "backfill_final_review_history: %s assignment #%s already has "
                         "correct date %s, skipping",
-                        rfctobe.name, assignment.id, date_str,
+                        rfctobe.name,
+                        assignment.id,
+                        date_str,
                     )
                     skipped += 1
                     continue
@@ -106,7 +108,10 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
                 logger.info(
                     "backfill_final_review_history: %supdated history_date for %s "
                     "assignment #%s → %s",
-                    prefix, rfctobe.name, assignment.id, date_str,
+                    prefix,
+                    rfctobe.name,
+                    assignment.id,
+                    date_str,
                 )
             else:
                 if not dry_run:
@@ -127,7 +132,10 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
                 logger.info(
                     "backfill_final_review_history: %screated history for %s "
                     "assignment #%s → %s",
-                    prefix, rfctobe.name, assignment.id, date_str,
+                    prefix,
+                    rfctobe.name,
+                    assignment.id,
+                    date_str,
                 )
             added += 1
 

--- a/rpc/lifecycle/final_review.py
+++ b/rpc/lifecycle/final_review.py
@@ -3,8 +3,6 @@
 import datetime
 import logging
 
-from django.utils import timezone
-
 logger = logging.getLogger(__name__)
 
 # (draft_name, start_date) — start_date is when the final_review_editor assignment was
@@ -55,8 +53,8 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
     skipped = 0
 
     for draft_name, date_str in FINAL_REVIEW_START_DATES:
-        start_date = timezone.make_aware(
-            datetime.datetime.strptime(date_str, "%Y-%m-%d").replace(hour=12)
+        start_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").replace(
+            hour=12, tzinfo=datetime.UTC
         )
 
         rfctobe = (
@@ -71,12 +69,16 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
             skipped += 1
             continue
 
-        assignments = Assignment.objects.filter(
-            rfc_to_be=rfctobe,
-            role__slug="final_review_editor",
-        ).select_related("role", "person")
+        assignment = (
+            Assignment.objects.filter(
+                rfc_to_be=rfctobe,
+                role__slug="final_review_editor",
+            )
+            .order_by("id")
+            .first()
+        )
 
-        if not assignments.exists():
+        if assignment is None:
             logger.warning(
                 "backfill_final_review_history: no final_review_editor assignment "
                 "for %s",
@@ -85,58 +87,44 @@ def backfill_final_review_history(dry_run: bool = False) -> tuple[int, int]:
             skipped += 1
             continue
 
-        for assignment in assignments:
-            existing = HistoricalAssignment.objects.filter(
-                id=assignment.id, history_type="+"
-            ).first()
+        existing_qs = HistoricalAssignment.objects.filter(
+            id=assignment.id, history_type="+"
+        )
+        count = existing_qs.count()
+        if count != 1:
+            logger.warning(
+                "backfill_final_review_history: expected 1 history entry for %s "
+                "assignment #%s, found %d, skipping",
+                rfctobe.name,
+                assignment.id,
+                count,
+            )
+            skipped += 1
+            continue
+        existing = existing_qs.get()
 
-            if existing:
-                if existing.history_date == start_date:
-                    logger.info(
-                        "backfill_final_review_history: %s assignment #%s already has "
-                        "correct date %s, skipping",
-                        rfctobe.name,
-                        assignment.id,
-                        date_str,
-                    )
-                    skipped += 1
-                    continue
-                if not dry_run:
-                    existing.history_date = start_date
-                    existing.save(update_fields=["history_date"])
-                prefix = "[DRY RUN] " if dry_run else ""
-                logger.info(
-                    "backfill_final_review_history: %supdated history_date for %s "
-                    "assignment #%s → %s",
-                    prefix,
-                    rfctobe.name,
-                    assignment.id,
-                    date_str,
-                )
-            else:
-                if not dry_run:
-                    HistoricalAssignment.objects.create(
-                        id=assignment.id,
-                        rfc_to_be=rfctobe,
-                        person=assignment.person,
-                        role=assignment.role,
-                        state=assignment.state,
-                        comment=assignment.comment,
-                        time_spent=assignment.time_spent,
-                        history_date=start_date,
-                        history_type="+",
-                        history_user=None,
-                        history_change_reason="Backfilled final review start date",
-                    )
-                prefix = "[DRY RUN] " if dry_run else ""
-                logger.info(
-                    "backfill_final_review_history: %screated history for %s "
-                    "assignment #%s → %s",
-                    prefix,
-                    rfctobe.name,
-                    assignment.id,
-                    date_str,
-                )
-            added += 1
+        if existing.history_date == start_date:
+            logger.info(
+                "backfill_final_review_history: %s assignment #%s already has "
+                "correct date %s, skipping",
+                rfctobe.name,
+                assignment.id,
+                date_str,
+            )
+            skipped += 1
+            continue
+        if not dry_run:
+            existing.history_date = start_date
+            existing.save(update_fields=["history_date"])
+        prefix = "[DRY RUN] " if dry_run else ""
+        logger.info(
+            "backfill_final_review_history: %supdated history_date for %s "
+            "assignment #%s → %s",
+            prefix,
+            rfctobe.name,
+            assignment.id,
+            date_str,
+        )
+        added += 1
 
     return added, skipped

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -47,6 +47,7 @@ def backfill_final_review_history_task(dry_run: bool = False):
     """
     from django.db import transaction
     from django.utils import timezone
+
     from rpc.lifecycle.final_review import backfill_final_review_history
     from rpc.models import TaskRun
 

--- a/rpc/tasks.py
+++ b/rpc/tasks.py
@@ -38,6 +38,49 @@ RPC_PERSON_NAME_MAP_CACHE_TTL = 20 * 60  # seconds
 
 
 @shared_task
+def backfill_final_review_history_task(dry_run: bool = False):
+    """One-time backfill of missing history creation entries for
+    final_review_editor assignments.
+
+    Guards against re-runs via TaskRun — subsequent calls are no-ops.
+    Pass dry_run=True to log what would be done without writing anything.
+    """
+    from django.db import transaction
+    from django.utils import timezone
+    from rpc.lifecycle.final_review import backfill_final_review_history
+    from rpc.models import TaskRun
+
+    TASK_NAME = "backfill_final_review_history"
+
+    if dry_run:
+        logger.info("%s: dry run — no changes will be saved", TASK_NAME)
+        added, skipped = backfill_final_review_history(dry_run=True)
+        logger.info("%s complete: %d would add, %d skipped", TASK_NAME, added, skipped)
+        return
+
+    with transaction.atomic():
+        task_run, created = TaskRun.objects.get_or_create(
+            task_name=TASK_NAME,
+            defaults={"last_run_at": timezone.now(), "is_running": False},
+        )
+        if not created:
+            logger.info(
+                "%s already ran on %s, skipping", TASK_NAME, task_run.last_run_at
+            )
+            return
+        task_run.is_running = True
+        task_run.save()
+
+    try:
+        added, skipped = backfill_final_review_history()
+        logger.info("%s complete: %d added, %d skipped", TASK_NAME, added, skipped)
+        task_run.last_run_at = timezone.now()
+    finally:
+        task_run.is_running = False
+        task_run.save()
+
+
+@shared_task
 def set_stream_manager_task(rfc_to_be_id: int):
     """Resolve and persist the stream_manager FK for a RfcToBe."""
     try:


### PR DESCRIPTION
resolves https://github.com/ietf-tools/purple/issues/1318

start dates have been compiled from legacy DB (`AUTH48` state change) and validated.
Task re-writes history and updates the create-date of the `final-review-editor` assignment