### PR TITLE
feat: show extended info for cluster members in table

### DIFF
--- a/client/app/components/ClusterReorder.vue
+++ b/client/app/components/ClusterReorder.vue
@@ -3,51 +3,83 @@
     <template #header>
       <CardHeader :title="`Cluster-Members C${props.cluster.number}`">
         <template #actions>
-          <Icon v-if="queueStatus === 'pending' || labelsStatus === 'pending'" name="ei:spinner-3" size="1.3rem" class="animate-spin" title="Loading additional information about cluster documents" />
-          <span v-else-if="queueStatus === 'error' || labelsStatus === 'error'" class="text-red-800 dark:text-red-400">
+          <Icon v-if="queueStatus === 'pending'" name="ei:spinner-3" size="1.3rem" class="animate-spin" title="Loading additional information about cluster documents" />
+          <span v-else-if="queueStatus === 'error'" class="text-red-800 dark:text-red-400">
             {{ queueError }}
-            {{ labelsError }}
           </span>
         </template>
       </CardHeader>
     </template>
-    <p class="italic text-sm">(drag to reorder)</p>
-    <ol ref="parent" class="min-w-[200px] mb-6">
-      <li v-for="(clusterDocument, index) in clusterDocumentsRef" :index="index" :key="clusterDocument.name"
-        class="flex justify-between items-center pl-2 cursor-ns-resize pr-1 py-1 mt-1 bg-white dark:bg-gray-700 border rounded-md border-gray-400 select-none">
-        <span class="flex items-center font-semibold text-sm w-[350px]">
-          <Icon name="fluent:re-order-dots-vertical-24-regular" class="mr-2" />
-          {{ clusterDocument.name }}
-        </span>
-
-        <span class="w-[200px]">
-          <span v-if="rfcToBeLabelsByName[clusterDocument.name]"
-            v-for="(label, labelIndex) in rfcToBeLabelsByName[clusterDocument.name]" :key="labelIndex">
-            <RpcLabel :label="label" />
-          </span>
-          <span v-else-if="labelsStatus === 'pending'">
-            <!-- <Icon name="ei:spinner-3" size="1.3rem" class="animate-spin" /> -->
-          </span>
-          <span v-else-if="labelsStatus === 'success' && queueStatus === 'success'"
-            title="Couldn't find rfcToBe in queue">
-            ?
-          </span>
-        </span>
-
-        <span class="w-[100px]">
-          <span v-if="enqueuedAtByDraftName[clusterDocument.name]">
-            <component :is="enqueuedAtByDraftName[clusterDocument.name]" />
-          </span>
-          <span v-else-if="queueStatus === 'pending'">
-            <!-- <Icon name="ei:spinner-3" size="1.3rem" class="animate-spin" /> -->
-          </span>
-        </span>
-
-        <button type="button" class="p-2 rounded-md bg-gray-100 text-gray-800 hover:bg-gray-200 focus:bg-gray-200"
-          :aria-label="`Remove ${clusterDocument.name}`"
-          @click="() => removeDocument(clusterDocument.name)">&times</button>
-      </li>
-    </ol>
+    <p class="italic text-sm mb-2">(drag to reorder)</p>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-gray-200 dark:border-gray-600 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          <th class="pb-2 w-6"></th>
+          <th class="pb-2">Document</th>
+          <th class="pb-2 w-48">Labels</th>
+          <th class="pb-2 w-40">Enqueue Date</th>
+          <th class="pb-2 w-56">Status</th>
+          <th class="pb-2 w-56">Assignees</th>
+          <th class="pb-2 w-36 text-center">Approvals Received</th>
+          <th class="pb-2 w-28"></th>
+        </tr>
+      </thead>
+      <tbody ref="parent">
+        <tr v-for="(clusterDocument, index) in clusterDocumentsRef" :index="index" :key="clusterDocument.name"
+          class="cursor-ns-resize bg-white dark:bg-gray-700 border-b border-gray-100 dark:border-gray-600 select-none hover:bg-gray-50 dark:hover:bg-gray-650">
+          <td class="py-2 pl-1 pr-2">
+            <Icon name="fluent:re-order-dots-vertical-24-regular" class="text-gray-400" />
+          </td>
+          <td class="py-2 pr-3 font-semibold">
+            {{ clusterDocument.name }}
+          </td>
+          <td class="py-2 pr-3">
+            <span v-for="(label, labelIndex) in labelsByDraftName[clusterDocument.name]" :key="labelIndex">
+              <RpcLabel :label="label" />
+            </span>
+          </td>
+          <td class="py-2 pr-3 text-gray-600 dark:text-gray-300">
+            <component v-if="enqueuedAtByDraftName[clusterDocument.name]" :is="enqueuedAtByDraftName[clusterDocument.name]" />
+          </td>
+          <td class="py-2 pr-3">
+            <template v-if="queueItemByDraftName[clusterDocument.name]?.assignmentSet?.length">
+              <span v-for="role in [...new Set(queueItemByDraftName[clusterDocument.name]?.assignmentSet?.map(a => a.role))]" :key="role"
+                class="mr-1">
+                <BaseBadge :label="role" />
+              </span>
+              <span v-if="queueItemByDraftName[clusterDocument.name]?.assignmentSet?.some(a => a.role === 'blocked')"
+                class="text-xs text-gray-500 dark:text-gray-400">
+                {{ queueItemByDraftName[clusterDocument.name]?.blockingReasons?.map(br => br.reason?.name).filter(Boolean).join(', ') }}
+              </span>
+            </template>
+          </td>
+          <td class="py-2 pr-3">
+            <ul class="space-y-0.5">
+              <li v-for="assignment in queueItemByDraftName[clusterDocument.name]?.assignmentSet" :key="assignment.id"
+                class="flex items-center gap-1.5 text-sm">
+                <BaseBadge :label="assignment.role" class="shrink-0" />
+                <span class="text-gray-700 dark:text-gray-300 truncate">
+                  {{ personById[assignment.person ?? -1]?.name ?? '—' }}
+                </span>
+              </li>
+            </ul>
+          </td>
+          <td class="py-2 pr-3 text-center">
+            <Anchor :href="`/docs/${clusterDocument.name}/approvals`"
+              class="text-violet-700 dark:text-violet-300 hover:underline whitespace-nowrap font-mono text-sm">
+              {{ queueItemByDraftName[clusterDocument.name]?.finalApproval?.filter(a => a.approved !== undefined).length ?? 0 }}
+              /
+              {{ queueItemByDraftName[clusterDocument.name]?.finalApproval?.length ?? 0 }}
+            </Anchor>
+          </td>
+          <td class="py-2 text-right">
+            <button type="button" class="p-1 rounded bg-gray-100 text-gray-800 hover:bg-gray-200 focus:bg-gray-200 text-xs"
+              :aria-label="`Remove ${clusterDocument.name}`"
+              @click="() => removeDocument(clusterDocument.name)">&times;</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
     <div class="flex mx-3 py-3 justify-end border-t border-gray-300">
       <BaseButton @click="handleSaveReorder">Save new order</BaseButton>
     </div>
@@ -56,7 +88,8 @@
 
 <script setup lang="ts">
 import { useDragAndDrop } from "fluid-dnd/vue";
-import { type Cluster, type RfcToBe, type Label, type QueueItem } from '~/purple_client'
+import { type Cluster, type RfcToBe, type QueueItem, type RpcPerson } from '~/purple_client'
+import { Anchor } from '#components'
 import BaseButton from './BaseButton.vue'
 import { calculateEnqueuedAtData, renderEnqueuedAt } from '../utils/queue'
 
@@ -80,6 +113,16 @@ const {
     lazy: true,
     default: () => [] as QueueItem[],
   }
+)
+
+const { data: people } = await useAsyncData(
+  'rpc-people-for-cluster',
+  () => api.rpcPersonList(),
+  { server: false, lazy: true, default: () => [] as RpcPerson[] }
+)
+
+const personById = computed(() =>
+  Object.fromEntries(people.value.map(p => [p.id, p]))
 )
 
 const snackbar = useSnackbar()
@@ -113,39 +156,11 @@ const enqueuedAtByDraftName = computed(() => queue.value.reduce((acc, queueItem)
 
 const clusterDocumentsRef = ref(props.cluster.documents ?? [])
 
-const { data: labels, status: labelsStatus, error: labelsError } = await useAsyncData(
-  `labels-lazy`,
-  () => api.labelsList(),
-  {
-    default: () => ([] as Label[]),
-    server: false,
-    lazy: true,
-  }
+const labelsByDraftName = computed(() =>
+  Object.fromEntries(
+    Object.entries(queueItemByDraftName.value).map(([name, item]) => [name, item?.labels ?? []])
+  )
 )
-
-type LabelsById = Record<number, Label | undefined>
-
-const labelsById = computed(() => labels.value.reduce((acc, label) => {
-  const { id } = label
-  if (id) {
-    acc[id] = label
-  }
-  return acc
-}, {} as LabelsById))
-
-type RfcToBeLabelsByName = Record<string, Label[] | undefined>
-
-const rfcToBeLabelsByName = computed(() => props.rfcsToBe?.reduce((acc, rfcToBe) => {
-  const { name } = rfcToBe
-  if (!name) {
-    throw Error('Expected item to have id')
-  }
-  if (labels.value.length > 0) {
-    const rfcToBeLabelsResolved = rfcToBe.labels.map(labelId => labelsById.value[labelId]).filter(item => !!item)
-    acc[name] = rfcToBeLabelsResolved.length > 0 ? rfcToBeLabelsResolved : undefined
-  }
-  return acc
-}, {} as RfcToBeLabelsByName) ?? {})
 
 const [parent] = useDragAndDrop(clusterDocumentsRef);
 

--- a/client/app/pages/clusters/[number].vue
+++ b/client/app/pages/clusters/[number].vue
@@ -21,7 +21,7 @@
     <DocumentDependenciesGraph v-if="filteredCluster" :cluster="filteredCluster" />
     <div v-else>No filtered cluster</div>
 
-    <ClusterReorder v-if="filteredCluster" :cluster="filteredCluster" :on-success="refresh" class="max-w-[800px]" :rfcs-to-be="rfcsToBe" />
+    <ClusterReorder v-if="filteredCluster" :cluster="filteredCluster" :on-success="refresh" :rfcs-to-be="rfcsToBe" />
 
     <ClusterMembershipHistory v-if="clusterNumber" :cluster-number="clusterNumber" class="mt-8 max-w-[800px]" />
   </div>


### PR DESCRIPTION
fix https://github.com/ietf-tools/purple/issues/1038 and fix https://github.com/ietf-tools/purple/issues/1120

show additional info in table
- labels
- blocking reasons
- assignments
- approval counts

<img width="1256" height="485" alt="image" src="https://github.com/user-attachments/assets/b0a64213-4601-49cd-b9cf-90e814de2cb8" />
