### PR TITLE
fix: allow import draft that was previously withdrawn

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -430,9 +430,11 @@ def submissions(request, *, rpcapi: rpcapi_client.PurpleApi):
     # Get submissions list from Datatracker
     with datatracker_api():
         submitted = rpcapi.submitted_to_rpc()
-    # Filter out I-Ds that already have an RfcToBe
+    # Filter out I-Ds that already have an active (non-withdrawn) RfcToBe
     already_in_queue = RfcToBe.objects.filter(
         draft__datatracker_id__in=[s.id for s in submitted]
+    ).exclude(
+        disposition__slug="withdrawn"
     ).values_list("draft__datatracker_id", flat=True)
     submitted = [s for s in submitted if s.id not in already_in_queue]
     return Response(SubmissionListItemSerializer(submitted, many=True).data)

--- a/rpc/api.py
+++ b/rpc/api.py
@@ -431,11 +431,11 @@ def submissions(request, *, rpcapi: rpcapi_client.PurpleApi):
     with datatracker_api():
         submitted = rpcapi.submitted_to_rpc()
     # Filter out I-Ds that already have an active (non-withdrawn) RfcToBe
-    already_in_queue = RfcToBe.objects.filter(
-        draft__datatracker_id__in=[s.id for s in submitted]
-    ).exclude(
-        disposition__slug="withdrawn"
-    ).values_list("draft__datatracker_id", flat=True)
+    already_in_queue = (
+        RfcToBe.objects.filter(draft__datatracker_id__in=[s.id for s in submitted])
+        .exclude(disposition__slug="withdrawn")
+        .values_list("draft__datatracker_id", flat=True)
+    )
     submitted = [s for s in submitted if s.id not in already_in_queue]
     return Response(SubmissionListItemSerializer(submitted, many=True).data)
 


### PR DESCRIPTION
current behavior: a draft ready to be imported, but that was previously withdrawn, does not show up on submission tab

expected behavior: it should be displayed on tab


solution: adapt filter to exclude withdrawn drafts